### PR TITLE
[feat] presignedUrl 이용해 클라이언트가 private s3 이미지 조회하기

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/s3/service/DiaryImageS3Service.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/s3/service/DiaryImageS3Service.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
+import java.net.URL;
 import java.time.Duration;
 
 @RequiredArgsConstructor
@@ -56,7 +57,7 @@ public class DiaryImageS3Service {
                 .build();
     }
 
-    public String generatePreSignedImageUrl(Long diaryId, Integer gridPosition) {
+    public URL generatePreSignedImageUrl(Long diaryId, Integer gridPosition) {
         if (!isImageExist(diaryId, gridPosition)) {
             throw new S3ImageNotFoundException(String.format("S3에 이미지가 존재하지 않습니다. Key: %s", getKeyName(diaryId, gridPosition)));
         }
@@ -66,7 +67,7 @@ public class DiaryImageS3Service {
         try {
             GetObjectPresignRequest getObjectPresignRequest = createGetObjectPresignRequest(keyName);
             PresignedGetObjectRequest preSignedRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
-            return preSignedRequest.url().toString();
+            return preSignedRequest.url();
         } catch (Exception e) {
             throw new S3PreSignUrlException(String.format("S3에서 프리사인 URL 생성 중 오류가 발생했습니다. Key: %s", keyName), e);
         }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -31,6 +31,9 @@ import static org.springframework.http.ResponseEntity.*;
 @Slf4j
 public class DiaryController {
 
+    private static final int MIN_PAINTING_IMAGE_SIZE = 1;
+    private static final int MAX_PAINTING_IMAGE_SIZE = 4;
+
     private final DiaryService diaryService;
     private final DiaryImageS3Service diaryImageS3Service;
 
@@ -54,7 +57,7 @@ public class DiaryController {
         }
 
         List<DiarySavedResponse> diaryResponsesWithPreSignedUrls = responses.diarySavedResponses().stream().map(savedDiary -> {
-            List<String> preSignedUrls = IntStream.rangeClosed(1, 4)
+            List<String> preSignedUrls = IntStream.rangeClosed(MIN_PAINTING_IMAGE_SIZE, MAX_PAINTING_IMAGE_SIZE)
                     .mapToObj(imageGridPosition -> {
                         try {
                             return diaryImageS3Service.generatePreSignedImageUrl(savedDiary.diaryId(), imageGridPosition);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -31,8 +31,8 @@ import static org.springframework.http.ResponseEntity.*;
 @Slf4j
 public class DiaryController {
 
-    private static final int MIN_PAINTING_IMAGE_SIZE = 1;
-    private static final int MAX_PAINTING_IMAGE_SIZE = 4;
+    private static final int MIN_PAINTING_IMAGE_POSITION = 1;
+    private static final int MAX_PAINTING_IMAGE_POSITION = 4;
 
     private final DiaryService diaryService;
     private final DiaryImageS3Service diaryImageS3Service;
@@ -57,7 +57,7 @@ public class DiaryController {
         }
 
         List<DiarySavedResponse> diaryResponsesWithPreSignedUrls = responses.diarySavedResponses().stream().map(savedDiary -> {
-            List<String> preSignedUrls = IntStream.rangeClosed(MIN_PAINTING_IMAGE_SIZE, MAX_PAINTING_IMAGE_SIZE)
+            List<String> preSignedUrls = IntStream.rangeClosed(MIN_PAINTING_IMAGE_POSITION, MAX_PAINTING_IMAGE_POSITION)
                     .mapToObj(imageGridPosition -> {
                         try {
                             return diaryImageS3Service.generatePreSignedImageUrl(savedDiary.diaryId(), imageGridPosition);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -1,11 +1,8 @@
 package com.startingblue.fourtooncookie.diary;
 
-import com.startingblue.fourtooncookie.aws.s3.service.DiaryImageS3Service;
-import com.startingblue.fourtooncookie.diary.domain.Diary;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryFavoriteRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryUpdateRequest;
-import com.startingblue.fourtooncookie.diary.dto.response.DiarySavedResponse;
 import com.startingblue.fourtooncookie.diary.dto.response.DiarySavedResponses;
 import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import jakarta.validation.constraints.Max;
@@ -16,12 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.springframework.http.ResponseEntity.*;
 
@@ -32,7 +24,6 @@ import static org.springframework.http.ResponseEntity.*;
 public class DiaryController {
 
     private final DiaryService diaryService;
-    private final DiaryImageS3Service diaryImageS3Service;
 
     @PostMapping
     public ResponseEntity<HttpStatus> createDiary(UUID memberId,

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -31,9 +31,6 @@ import static org.springframework.http.ResponseEntity.*;
 @Slf4j
 public class DiaryController {
 
-    private static final int MIN_PAINTING_IMAGE_POSITION = 1;
-    private static final int MAX_PAINTING_IMAGE_POSITION = 4;
-
     private final DiaryService diaryService;
     private final DiaryImageS3Service diaryImageS3Service;
 
@@ -55,31 +52,7 @@ public class DiaryController {
         if (responses.diarySavedResponses().isEmpty()) {
             return noContent().build();
         }
-
-        List<DiarySavedResponse> diaryResponsesWithPreSignedUrls = responses.diarySavedResponses().stream().map(savedDiary -> {
-            List<String> preSignedUrls = IntStream.rangeClosed(MIN_PAINTING_IMAGE_POSITION, MAX_PAINTING_IMAGE_POSITION)
-                    .mapToObj(imageGridPosition -> {
-                        try {
-                            return diaryImageS3Service.generatePreSignedImageUrl(savedDiary.diaryId(), imageGridPosition);
-                        } catch (Exception e) {
-                            log.error("Failed to generate pre-signed image url", e);
-                            return null;
-                        }
-                    })
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-
-            return new DiarySavedResponse(
-                    savedDiary.diaryId(),
-                    savedDiary.content(),
-                    savedDiary.isFavorite(),
-                    savedDiary.diaryDate(),
-                    preSignedUrls,
-                    savedDiary.characterId()
-            );
-        }).collect(Collectors.toList());
-
-        return ok(new DiarySavedResponses(diaryResponsesWithPreSignedUrls));
+        return ok(responses);
     }
 
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -1,8 +1,11 @@
 package com.startingblue.fourtooncookie.diary;
 
+import com.startingblue.fourtooncookie.aws.s3.service.DiaryImageS3Service;
+import com.startingblue.fourtooncookie.diary.domain.Diary;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryFavoriteRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryUpdateRequest;
+import com.startingblue.fourtooncookie.diary.dto.response.DiarySavedResponse;
 import com.startingblue.fourtooncookie.diary.dto.response.DiarySavedResponses;
 import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import jakarta.validation.constraints.Max;
@@ -13,6 +16,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.springframework.http.ResponseEntity.*;
@@ -24,6 +30,7 @@ import static org.springframework.http.ResponseEntity.*;
 public class DiaryController {
 
     private final DiaryService diaryService;
+    private final DiaryImageS3Service diaryImageS3Service;
 
     @PostMapping
     public ResponseEntity<HttpStatus> createDiary(UUID memberId,
@@ -37,14 +44,46 @@ public class DiaryController {
             UUID memberId,
             @RequestParam(defaultValue = "0") @Min(0) @Max(200) final int pageNumber,
             @RequestParam(defaultValue = "10") @Min(1) @Max(10) final int pageSize) {
-        DiarySavedResponses responses = DiarySavedResponses.of(diaryService.readDiariesByMemberId(memberId, pageNumber, pageSize));
 
-        if (responses.diarySavedResponses().isEmpty()) {
+        List<Diary> diaries = diaryService.readDiariesByMemberId(memberId, pageNumber, pageSize);
+
+        if (diaries.isEmpty()) {
             return noContent().build();
         }
-        return ok(responses);
-    }
 
+        DiarySavedResponses responses = DiarySavedResponses.of(diaries);
+
+        List<DiarySavedResponse> diaryResponsesWithPreSignedUrls = new ArrayList<>();
+        for (DiarySavedResponse savedDiary : responses.diarySavedResponses()) {
+            List<String> preSignedUrls = new ArrayList<>();
+
+            for (int imageGridPosition = 1; imageGridPosition <= 4; imageGridPosition++) {
+                try {
+                    String preSignedUrl = diaryImageS3Service.generatePreSignedImageUrl(savedDiary.diaryId(), imageGridPosition);
+                    preSignedUrls.add(preSignedUrl);
+                } catch (Exception e) {
+                    log.error("Failed to generate pre-signed image url", e);
+                }
+            }
+
+            preSignedUrls.removeIf(Objects::isNull);
+
+            DiarySavedResponse updatedDiary = new DiarySavedResponse(
+                    savedDiary.diaryId(),
+                    savedDiary.content(),
+                    savedDiary.isFavorite(),
+                    savedDiary.diaryDate(),
+                    preSignedUrls,
+                    savedDiary.characterId()
+            );
+
+            diaryResponsesWithPreSignedUrls.add(updatedDiary);
+        }
+
+        DiarySavedResponses updatedResponses = new DiarySavedResponses(diaryResponsesWithPreSignedUrls);
+        return ok(updatedResponses);
+    }
+    
     @PutMapping("/{diaryId}")
     public ResponseEntity<HttpStatus> updateDiary(@PathVariable final Long diaryId,
                                             @RequestBody final DiaryUpdateRequest request) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -46,7 +46,7 @@ public class DiaryController {
 
     @GetMapping("/timeline")
     public ResponseEntity<DiarySavedResponses> readDiariesByMember (
-            @RequestParam UUID memberId,
+            UUID memberId,
             @RequestParam(defaultValue = "0") @Min(0) @Max(200) final int pageNumber,
             @RequestParam(defaultValue = "10") @Min(1) @Max(10) final int pageSize) {
 

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/aws/s3/service/DiaryImageS3ServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/aws/s3/service/DiaryImageS3ServiceTest.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 import java.net.URI;
 import java.net.MalformedURLException;
+import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -106,10 +107,10 @@ public class DiaryImageS3ServiceTest {
         when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presignedGetObjectRequest);
 
         // 테스트 대상 메서드 호출
-        String url = diaryImageS3Service.generatePreSignedImageUrl(diaryId, gridPosition);
+        URL url = diaryImageS3Service.generatePreSignedImageUrl(diaryId, gridPosition);
 
         // 결과 검증
-        assertEquals("http://example.com", url);
+        assertEquals(new URL("http://example.com"), url);
 
         // 상호작용 검증
         verify(s3Client).headObject(any(HeadObjectRequest.class));


### PR DESCRIPTION
# [feat] presignedUrl 이용해 클라이언트가 private s3 데이터 조회하기
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-326
---
#### 구현 내용
- DiaryController
    - `DiaryImageS3Service` 의존성 추가
    - `@GetMapping("/timeline")` 에서 응답 값 paintingImageUrls에 presignedUrl 생성 후 DTO로 변환하는 코드 추가