### PR TITLE
fix: createDiary에서 일기 생성 비동기 호출로 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -55,7 +56,7 @@ public class DiaryService {
 
         Diary diary = buildDiary(request, member, character);
         diaryRepository.save(diary);
-        invokeImageGenerateLambdaAsync(diary, character);
+        CompletableFuture.runAsync(() -> invokeImageGenerateLambdaAsync(diary, character));
     }
 
     private Diary buildDiary(DiarySaveRequest request, Member member, Character character) {


### PR DESCRIPTION
# fix: createDiary에서 일기 생성 비동기 호출로 변경
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-329
---
* 구현 내용
createDiary에서 일기 생성 비동기 호출로 변경

* 추가 발생한 문제(논의 사항)
