### PR TITLE
[bug] 일기 수정시, 일기 이미지 생성 호출 비동기로 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -123,7 +123,7 @@ public class DiaryService {
         Character character = characterService.readById(request.characterId());
         existedDiary.update(request.content(), character);
         diaryRepository.save(existedDiary);
-        invokeImageGenerateLambdaAsync(existedDiary, character);
+        CompletableFuture.runAsync(() -> invokeImageGenerateLambdaAsync(existedDiary, character));
     }
 
     public void deleteDiary(Long diaryId) {


### PR DESCRIPTION
# fix: 일기 수정시, 일기 이미지 생성 호출 비동기로 변경
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-
---
* 구현 내용


* 추가 발생한 문제(논의 사항)
