### PR TITLE
[hotfix] 람다호출을 자바 코드로 비동기 처리한 것을, 람다 invocationType 변경을 통해 비동기로 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/LambdaInvoker.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/LambdaInvoker.java
@@ -3,6 +3,7 @@ package com.startingblue.fourtooncookie.aws.lambda;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.core.SdkBytes;
 
@@ -16,6 +17,7 @@ public class LambdaInvoker {
         InvokeRequest invokeRequest = InvokeRequest.builder()
                 .functionName(functionName)
                 .payload(SdkBytes.fromUtf8String(payload))
+                .invocationType(InvocationType.EVENT)
                 .build();
 
         lambdaClient.invoke(invokeRequest);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -60,7 +59,7 @@ public class DiaryService {
 
         Diary diary = buildDiary(request, member, character);
         diaryRepository.save(diary);
-        CompletableFuture.runAsync(() -> invokeImageGenerateLambdaAsync(diary, character));
+        invokeImageGenerateLambdaAsync(diary, character);
     }
 
     private Diary buildDiary(DiarySaveRequest request, Member member, Character character) {
@@ -140,7 +139,7 @@ public class DiaryService {
         Character character = characterService.readById(request.characterId());
         existedDiary.update(request.content(), character);
         diaryRepository.save(existedDiary);
-        CompletableFuture.runAsync(() -> invokeImageGenerateLambdaAsync(existedDiary, character));
+        invokeImageGenerateLambdaAsync(existedDiary, character);
     }
 
     public void deleteDiary(Long diaryId) {


### PR DESCRIPTION
# hotfix: 람다호출을 자바 코드로 비동기 처리한 것을, 람다 invocationType 변경을 통해 비동기로 변경
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-
---
* 구현 내용


* 추가 발생한 문제(논의 사항)
