### PR TITLE
[bug] DiaryImageGenerationLambdaPayload 응답 데이터 id 에서 diaryId로 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/diaryImageGenerationPayload/DiaryImageGenerationLambdaPayload.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/diaryImageGenerationPayload/DiaryImageGenerationLambdaPayload.java
@@ -1,5 +1,5 @@
 package com.startingblue.fourtooncookie.aws.lambda.diaryImageGenerationPayload;
 
-public record DiaryImageGenerationLambdaPayload(Long id, String content, DiaryImageGenerationCharacterPayload character) {
+public record DiaryImageGenerationLambdaPayload(Long diaryId, String content, DiaryImageGenerationCharacterPayload character) {
 
 }


### PR DESCRIPTION
# hotfix: DiaryImageGenerationLambdaPayload 응답 데이터 id 에서 diaryId로 변경
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-
---
* 구현 내용


* 추가 발생한 문제(논의 사항)
