### PR TITLE
feat: 이미지 생성 람다 호출 중 에러 발생시 체크하는 로직 추가

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/LambdaInvoker.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/aws/lambda/LambdaInvoker.java
@@ -1,6 +1,7 @@
 package com.startingblue.fourtooncookie.aws.lambda;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
@@ -9,17 +10,25 @@ import software.amazon.awssdk.core.SdkBytes;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LambdaInvoker {
 
     private final LambdaClient lambdaClient;
 
     public void invokeLambda(String functionName, String payload) {
-        InvokeRequest invokeRequest = InvokeRequest.builder()
-                .functionName(functionName)
-                .payload(SdkBytes.fromUtf8String(payload))
-                .invocationType(InvocationType.EVENT)
-                .build();
+        try {
+            InvokeRequest invokeRequest = InvokeRequest.builder()
+                    .functionName(functionName)
+                    .payload(SdkBytes.fromUtf8String(payload))
+                    .invocationType(InvocationType.REQUEST_RESPONSE)
+                    .build();
 
-        lambdaClient.invoke(invokeRequest);
+            var response = lambdaClient.invoke(invokeRequest);
+            log.info("Lambda invoked: {}", response.payload().asUtf8String());
+        } catch (Exception e) {
+            log.error("Lambda invocation failed: {}", e.getMessage());
+            throw new RuntimeException("Lambda 호출 실패", e);
+        }
     }
+
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/AsyncConfig.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/AsyncConfig.java
@@ -1,0 +1,35 @@
+package com.startingblue.fourtooncookie.config;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+import static org.hibernate.query.sqm.tree.SqmNode.log;
+
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "taskExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);   // 기본 스레드 수
+        executor.setMaxPoolSize(20);    // 최대 스레드 수
+        executor.setQueueCapacity(100); // 작업 큐 크기
+        executor.setThreadNamePrefix("AsyncThread-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (throwable, method, obj) -> {
+            log.error("비동기 작업 중 예외 발생");
+        };
+    }
+}
+


### PR DESCRIPTION
# feat: 이미지 생성 람다 호출 중 에러 발생시 체크하는 로직 추가
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-335
---
## 구현 내용
시나리오: 클라이언트가 서버에 비동기 요청을 보내고
서버는 클라이언트에게 즉시 일기 생성 요청을 받았다는 응답을 반환하고, 새로운 스레드(비동기)로 AWS 람다 요청을 한다. AWS 람다 요청(Dalle-3)가 실패하면 Diary의 `contet` 필드를 `"일기 생성 중 오류가 발생했습니다. 일기를 삭제 후 다시 생성해 주세요."` 로 수정한다.

- LambdaInvoker 요청타입을 `EVENT` 에서 `REQUEST_RESPONSE`로 변경해 예외 여부 응답을 받음
- LambdaInvoker 에서 예외가 발생하면  Diary의 `contet` 필드를 `"일기 생성 중 오류가 발생했습니다. 일기를 삭제 후 다시 생성해 주세요."` 로 수정한다.

## 추가 발생한 문제(논의 사항)
stable diffusion의 경우 SQS 를 이용해 에러를 처리할 예정
**BUT** dalle-3 의 경우 지금과 같이 Diary의 content 필드를 임의로 수정
추 후 dalle-3의 경우에도 로그를 이용한 알림 방식으로 에러를 알리는게 좋아보임