### PR TITLE
feat: 일기 정상 생성 시 diaryId 응답 하도록 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -3,6 +3,7 @@ package com.startingblue.fourtooncookie.diary;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryFavoriteRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryUpdateRequest;
+import com.startingblue.fourtooncookie.diary.dto.response.DiaryCreatedResponse;
 import com.startingblue.fourtooncookie.diary.dto.response.DiarySavedResponses;
 import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import jakarta.validation.constraints.Max;
@@ -26,10 +27,10 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping
-    public ResponseEntity<HttpStatus> createDiary(UUID memberId,
-                                                  @RequestBody final DiarySaveRequest request) {
-        diaryService.createDiary(request, memberId);
-        return status(HttpStatus.CREATED).build();
+    public ResponseEntity<DiaryCreatedResponse> createDiary(UUID memberId,
+                                                            @RequestBody final DiarySaveRequest request) {
+        DiaryCreatedResponse createdDiaryId = new DiaryCreatedResponse(diaryService.createDiary(request, memberId));
+        return ResponseEntity.ok(createdDiaryId);
     }
 
     @GetMapping("/timeline")

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/dto/response/DiaryCreatedResponse.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/dto/response/DiaryCreatedResponse.java
@@ -1,0 +1,4 @@
+package com.startingblue.fourtooncookie.diary.dto.response;
+
+public record DiaryCreatedResponse(Long diaryId) {
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -44,7 +44,7 @@ public class DiaryService {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DiaryImageS3Service diaryImageS3Service;
 
-    public void createDiary(final DiarySaveRequest request, final UUID memberId) {
+    public Long createDiary(final DiarySaveRequest request, final UUID memberId) {
         Member member = memberService.readById(memberId);
         Character character = characterService.readById(request.characterId());
         verifyUniqueDiary(memberId, request.diaryDate());
@@ -52,6 +52,7 @@ public class DiaryService {
         Diary diary = buildDiary(request, member, character);
         diaryRepository.save(diary);
         applicationEventPublisher.publishEvent(new DiaryLambdaCallEvent(diary, character));
+        return diary.getId();
     }
 
     private Diary buildDiary(DiarySaveRequest request, Member member, Character character) {


### PR DESCRIPTION
# [feat] 다이어리 생성 시 diaryId 응답 하도록 변경
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-344
---
* 구현 내용
다이어리 생성 시 diaryId 응답 하도록 변경

```
{
    "diaryId": 1
}
```

