### PR TITLE
feat: Diary 현재 상태 기능 추가 (생성 중, 완료, 생성 실패)

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -48,6 +48,11 @@ public final class Diary extends BaseEntity {
     @NotNull(message = "멤버 아이디는 필수 입니다.")
     private UUID memberId;
 
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "일기 상태는 필수 입니다.")
+    @Builder.Default
+    private DiaryStatus status = DiaryStatus.IN_PROGRESS;
+
     public static DiaryBuilder builder() {
         return new CustomDiaryBuilder();
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -61,6 +61,7 @@ public final class Diary extends BaseEntity {
                        Character character) {
         this.content = content;
         this.character = character;
+        this.status = DiaryStatus.IN_PROGRESS;
         validate();
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -58,10 +58,11 @@ public final class Diary extends BaseEntity {
     }
 
     public void update(String content,
-                       Character character) {
+                       Character character,
+                       DiaryStatus status) {
         this.content = content;
         this.character = character;
-        this.status = DiaryStatus.IN_PROGRESS;
+        this.status = status;
         validate();
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -74,6 +74,10 @@ public final class Diary extends BaseEntity {
         this.paintingImageUrls = new ArrayList<>(paintingImageUrls);
     }
 
+    public void updateDiaryStatus(DiaryStatus status) {
+        this.status = status;
+    }
+
     public boolean isOwner(UUID memberId) {
         return this.memberId.equals(memberId);
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryStatus.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryStatus.java
@@ -1,16 +1,7 @@
 package com.startingblue.fourtooncookie.diary.domain;
 
-import lombok.Getter;
-
-@Getter
 public enum DiaryStatus {
-    IN_PROGRESS("생성 중"),
-    COMPLETED("완료"),
-    FAILED("생성 실패");
-
-    private final String description;
-
-    DiaryStatus(String description) {
-        this.description = description;
-    }
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryStatus.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryStatus.java
@@ -1,0 +1,16 @@
+package com.startingblue.fourtooncookie.diary.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum DiaryStatus {
+    IN_PROGRESS("생성 중"),
+    COMPLETED("완료"),
+    FAILED("생성 실패");
+
+    private final String description;
+
+    DiaryStatus(String description) {
+        this.description = description;
+    }
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -103,7 +103,7 @@ public class DiaryService {
     public void updateDiary(Long diaryId, DiaryUpdateRequest request) {
         Diary existedDiary = readById(diaryId);
         Character character = characterService.readById(request.characterId());
-        existedDiary.update(request.content(), character);
+        existedDiary.update(request.content(), character, DiaryStatus.IN_PROGRESS);
         diaryRepository.save(existedDiary);
         applicationEventPublisher.publishEvent(new DiaryLambdaCallEvent(existedDiary, character));
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -5,6 +5,7 @@ import com.startingblue.fourtooncookie.character.domain.Character;
 import com.startingblue.fourtooncookie.character.service.CharacterService;
 import com.startingblue.fourtooncookie.diary.domain.Diary;
 import com.startingblue.fourtooncookie.diary.domain.DiaryRepository;
+import com.startingblue.fourtooncookie.diary.domain.DiaryStatus;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
 import com.startingblue.fourtooncookie.diary.dto.request.DiaryUpdateRequest;
 import com.startingblue.fourtooncookie.diary.exception.DiaryDuplicateException;
@@ -62,6 +63,7 @@ public class DiaryService {
                 .isFavorite(false)
                 .diaryDate(request.diaryDate())
                 .paintingImageUrls(Collections.emptyList())
+                .status(DiaryStatus.IN_PROGRESS)
                 .character(character)
                 .memberId(member.getId())
                 .build();

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/event/DiaryLambdaCallEventListener.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/event/DiaryLambdaCallEventListener.java
@@ -2,6 +2,7 @@ package com.startingblue.fourtooncookie.event;
 
 import com.startingblue.fourtooncookie.aws.lambda.LambdaInvoker;
 import com.startingblue.fourtooncookie.diary.domain.Diary;
+import com.startingblue.fourtooncookie.diary.domain.DiaryStatus;
 import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import com.startingblue.fourtooncookie.event.domain.DiaryLambdaCallEvent;
 import jakarta.transaction.Transactional;
@@ -33,6 +34,8 @@ public class DiaryLambdaCallEventListener {
     private void handleLambdaInvocationFailure(Diary diary, Throwable ex) {
         log.error("Lambda 호출 중 오류 발생, 저장된 일기 삭제: {}", ex.getMessage());
         Diary foundDiary = diaryService.readById(diary.getId()); // todo 트랜잭션 변경으로 영속성 컨텍스트가 변경 될 것 같아 우선 다시 가져옴. 테스트 필요
-        foundDiary.update("일기 생성 중 오류가 발생했습니다. 일기를 삭제 후 다시 생성해 주세요.", diary.getCharacter());
+        foundDiary.update("일기 생성 중 오류가 발생했습니다. 일기를 삭제 후 다시 생성해 주세요.",
+                diary.getCharacter(),
+                DiaryStatus.FAILED);
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/event/DiaryLambdaCallEventListener.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/event/DiaryLambdaCallEventListener.java
@@ -26,6 +26,7 @@ public class DiaryLambdaCallEventListener {
     public void handleDiaryLambdaCallEvent(DiaryLambdaCallEvent event) {
         try {
             lambdaInvoker.invokeImageGenerateLambdaAsync(event.diary(), event.character());
+            event.diary().updateDiaryStatus(DiaryStatus.COMPLETED);
         } catch (RuntimeException e) {
             handleLambdaInvocationFailure(event.diary(), e);
         }

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryTest.java
@@ -183,7 +183,7 @@ public class DiaryTest {
                 .build();
 
         String newContent = "New content";
-        diary.update(newContent, character);
+        diary.update(newContent, character, DiaryStatus.IN_PROGRESS);
 
         assertThat(diary.getContent()).isEqualTo(newContent);
         assertThat(diary.getCharacter()).isEqualTo(character);
@@ -201,7 +201,7 @@ public class DiaryTest {
                 .build();
 
         assertThatThrownBy(() -> {
-            diary.update("", character);
+            diary.update("", character, DiaryStatus.IN_PROGRESS);
         }).isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("일기 내용은 필수 입니다.");
     }
@@ -218,7 +218,7 @@ public class DiaryTest {
                 .build();
 
         assertThatThrownBy(() -> {
-            diary.update("Updated content", null);
+            diary.update("Updated content", null, DiaryStatus.IN_PROGRESS);
         }).isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("일기에 그려질 캐릭터는 필수 입니다.");
     }


### PR DESCRIPTION
# [feat] Diary 현재 상태 기능 추가 (생성 중, 완료, 생성 실패)
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-349
---

### 구현 내용

#### DiaryStatus
```    
IN_PROGRESS("생성 중"),
COMPLETED("완료"),
FAILED("생성 실패");
```

#### 흐름
1. 클라이언트가 이미지 생성 요청을 보내면 서버에서 다이어리 상태를 `IN_PROGRESS` 로 지정
2. 서버는 람다에서 이미지 생성 요청을 보냄
3. 람다는 이미지 생성 여부에 따라 `COMPLETED`, `FAILED` 상태로 변경 해야함.
4. 클라이언트는 다이어리 상태가 `FAILED` 인 경우 별도로 처리

### 추가로 해야 할 작업
- 클라이언트와 서버간의 요청과 응답을 맞춰야함