### PR TITLE
feat: DiarySavedResponse DTO 상태 응답 추가

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/dto/response/DiarySavedResponse.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/dto/response/DiarySavedResponse.java
@@ -1,6 +1,7 @@
 package com.startingblue.fourtooncookie.diary.dto.response;
 
 import com.startingblue.fourtooncookie.diary.domain.Diary;
+import com.startingblue.fourtooncookie.diary.domain.DiaryStatus;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -13,7 +14,8 @@ public record DiarySavedResponse(
         boolean isFavorite,
         LocalDate diaryDate,
         List<String> paintingImageUrls,
-        Long characterId
+        Long characterId,
+        DiaryStatus diaryStatus
 ) {
     public static DiarySavedResponse of(Diary diary) {
         return DiarySavedResponse.builder()
@@ -26,6 +28,7 @@ public record DiarySavedResponse(
                         .map(String::valueOf)
                         .toList())
                 .characterId(diary.getCharacter().getId())
+                .diaryStatus(diary.getStatus())
                 .build();
     }
 }


### PR DESCRIPTION
# [feat] DiarySavedResponse DTO 상태 응답 추가
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-352
---
* 구현 내용
Diary 조회시 응답값 (DiarySavedResponse)
```
{
    "diarySavedResponses": [
        {
            "diaryId": 1,
            "content": "asd\nabc나는오늘하루기분2이 워ㅁㄴㅇasd",
            "isFavorite": false,
            "diaryDate": "2024-07-18",
            "paintingImageUrls": [],
            "characterId": 1,
            "diaryStatus": "IN_PROGRESS"
        }
    ]
}
```
