### PR TITLE
[feat] 작품, 캐릭터 조회는 인증없이 가능하도록 변경

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
@@ -37,7 +37,7 @@ public class AuthenticationFilter extends HttpFilter {
         }
 
         try {
-            UUID memberId = extractMemberIdFromToken(request);
+            UUID memberId = extractUUIDFromToken(request);
             log.info("Login attempt for memberId: {}", memberId);
 
             if (isSignupRequest(requestURI, method)) {
@@ -47,7 +47,7 @@ public class AuthenticationFilter extends HttpFilter {
                 return;
             }
 
-            handleExistingMemberAuthentication(request, response, chain, memberId);
+            handleRequestByUUID(request, response, chain, memberId);
 
         } catch (AuthenticationException e) {
             log.error("Authentication failed: {}", e.getMessage());
@@ -60,7 +60,7 @@ public class AuthenticationFilter extends HttpFilter {
                 (method.equalsIgnoreCase("GET") && (requestURI.startsWith("/character") || requestURI.startsWith("/artwork")));
     }
 
-    private UUID extractMemberIdFromToken(HttpServletRequest request) {
+    private UUID extractUUIDFromToken(HttpServletRequest request) {
         String token = jwtExtractor.resolveToken(request);
         Claims claims = jwtExtractor.parseToken(token);
         return UUID.fromString(claims.getSubject());
@@ -70,7 +70,7 @@ public class AuthenticationFilter extends HttpFilter {
         request.setAttribute("memberId", memberId);
     }
 
-    private void handleExistingMemberAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, UUID memberId)
+    private void handleRequestByUUID(HttpServletRequest request, HttpServletResponse response, FilterChain chain, UUID memberId)
             throws IOException, ServletException {
         if (isExistsMember(memberId)) {
             log.info("Login success for memberId: {}", memberId);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
@@ -28,7 +28,11 @@ public class AuthenticationFilter extends HttpFilter {
             throws IOException, ServletException {
         String requestURI = request.getRequestURI();
         try {
-            if (requestURI.startsWith("/h2-console") || requestURI.startsWith("/health")) {
+            if (requestURI.startsWith("/h2-console") || requestURI.startsWith("/health") ||
+                (request.getMethod().equalsIgnoreCase("GET") &&
+                    (requestURI.startsWith("/character") || requestURI.startsWith("/artwork"))
+                )
+            ) {
                 chain.doFilter(request, response);
                 return;
             }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
@@ -26,39 +26,59 @@ public class AuthenticationFilter extends HttpFilter {
     @Override
     protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
+        log.info("doFilter() called with requestURI: {}, method: {}", request.getRequestURI(), request.getMethod());
+
         String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        if (shouldBypassAuthentication(requestURI, method)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         try {
-            if (requestURI.startsWith("/h2-console") || requestURI.startsWith("/health") ||
-                (request.getMethod().equalsIgnoreCase("GET") &&
-                    (requestURI.startsWith("/character") || requestURI.startsWith("/artwork"))
-                )
-            ) {
+            UUID memberId = extractMemberIdFromToken(request);
+            log.info("Login attempt for memberId: {}", memberId);
+
+            if (isSignupRequest(requestURI, method)) {
+                log.info("Processing signup request for URI: {}", requestURI);
+                setMemberIdAttribute(request, memberId);
                 chain.doFilter(request, response);
                 return;
             }
 
-            String token = jwtExtractor.resolveToken(request);
-            Claims claims = jwtExtractor.parseToken(token);
-            UUID memberId = UUID.fromString(claims.getSubject());
-            log.info("login attempt memberId: {}", memberId);
+            handleExistingMemberAuthentication(request, response, chain, memberId);
 
-            if (isSignupRequest(requestURI, request.getMethod())) {
-                request.setAttribute("memberId", memberId);
-                chain.doFilter(request, response);
-                return;
-            }
-
-            if (isExistsMember(memberId)) {
-                log.info("login success memberId: {}", memberId);
-                request.setAttribute("memberId", memberId);
-                chain.doFilter(request, response);
-            } else {
-                log.error("Member with id {} not found", memberId);
-                response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("Member with id %s not found", memberId));
-            }
         } catch (AuthenticationException e) {
             log.error("Authentication failed: {}", e.getMessage());
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication failed: " + e.getMessage());
+        }
+    }
+
+    private boolean shouldBypassAuthentication(String requestURI, String method) {
+        return requestURI.startsWith("/h2-console") || requestURI.startsWith("/health") ||
+                (method.equalsIgnoreCase("GET") && (requestURI.startsWith("/character") || requestURI.startsWith("/artwork")));
+    }
+
+    private UUID extractMemberIdFromToken(HttpServletRequest request) {
+        String token = jwtExtractor.resolveToken(request);
+        Claims claims = jwtExtractor.parseToken(token);
+        return UUID.fromString(claims.getSubject());
+    }
+
+    private void setMemberIdAttribute(HttpServletRequest request, UUID memberId) {
+        request.setAttribute("memberId", memberId);
+    }
+
+    private void handleExistingMemberAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, UUID memberId)
+            throws IOException, ServletException {
+        if (isExistsMember(memberId)) {
+            log.info("Login success for memberId: {}", memberId);
+            setMemberIdAttribute(request, memberId);
+            chain.doFilter(request, response);
+        } else {
+            log.error("Member with id {} not found", memberId);
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("Member with id %s not found", memberId));
         }
     }
 


### PR DESCRIPTION
# [feat] 작품, 캐릭터 조회는 인증없이 가능하도록 변경
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-354
---
* 구현 내용
`[GET] /artwork`
`[GET] /chacater`
에 대해 필터에서 jwt 토큰을 검증했던 부분을 삭제
