### PR TITLE
[feat] DiaryPaintingImageStatus 추가

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -1,6 +1,7 @@
 package com.startingblue.fourtooncookie.diary.domain;
 
 import com.startingblue.fourtooncookie.character.domain.Character;
+import com.startingblue.fourtooncookie.diary.domain.converter.DiaryPaintingImageGenerationStatusListConverter;
 import com.startingblue.fourtooncookie.global.domain.BaseEntity;
 import com.startingblue.fourtooncookie.global.converter.jpa.UrlListToStringConverter;
 import jakarta.persistence.*;
@@ -53,6 +54,10 @@ public final class Diary extends BaseEntity {
     @Builder.Default
     private DiaryStatus status = DiaryStatus.IN_PROGRESS;
 
+    @Convert(converter = DiaryPaintingImageGenerationStatusListConverter.class)
+    @Builder.Default
+    private List<DiaryPaintingImageGenerationStatus> paintingImageGenerationStatuses = new ArrayList<>();
+
     public static DiaryBuilder builder() {
         return new CustomDiaryBuilder();
     }
@@ -74,8 +79,16 @@ public final class Diary extends BaseEntity {
         this.paintingImageUrls = new ArrayList<>(paintingImageUrls);
     }
 
+    public void updatePaintingImageGenerationStatus(int index, DiaryPaintingImageGenerationStatus status) {
+        paintingImageGenerationStatuses.set(index, status);
+    }
+
     public void updateDiaryStatus(DiaryStatus status) {
         this.status = status;
+    }
+
+    public boolean isCompletedDiary() {
+        return status == DiaryStatus.COMPLETED;
     }
 
     public boolean isOwner(UUID memberId) {
@@ -111,6 +124,7 @@ public final class Diary extends BaseEntity {
                 Objects.equals(content, diary.content) &&
                 Objects.equals(diaryDate, diary.diaryDate) &&
                 Objects.equals(paintingImageUrls, diary.paintingImageUrls) &&
+                Objects.equals(paintingImageGenerationStatuses, diary.paintingImageGenerationStatuses) &&
                 Objects.equals(character, diary.character) &&
                 Objects.equals(memberId, diary.memberId) &&
                 Objects.equals(getCreatedDateTime(), diary.getCreatedDateTime()) &&

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/Diary.java
@@ -86,11 +86,7 @@ public final class Diary extends BaseEntity {
     public void updateDiaryStatus(DiaryStatus status) {
         this.status = status;
     }
-
-    public boolean isCompletedDiary() {
-        return status == DiaryStatus.COMPLETED;
-    }
-
+    
     public boolean isOwner(UUID memberId) {
         return this.memberId.equals(memberId);
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryPaintingImageGenerationStatus.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryPaintingImageGenerationStatus.java
@@ -1,0 +1,7 @@
+package com.startingblue.fourtooncookie.diary.domain;
+
+public enum DiaryPaintingImageGenerationStatus {
+    GENERATING,    // 이미지 생성 중 - 람다에 보내는 순간
+    SUCCESS,       // 이미지 생성 성공
+    FAILURE        // 이미지 생성 실패
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/converter/DiaryPaintingImageGenerationStatusListConverter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/converter/DiaryPaintingImageGenerationStatusListConverter.java
@@ -1,0 +1,56 @@
+package com.startingblue.fourtooncookie.diary.domain.converter;
+
+import com.startingblue.fourtooncookie.diary.domain.DiaryPaintingImageGenerationStatus;
+import com.startingblue.fourtooncookie.global.converter.exception.ConversionException;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Converter
+@Component
+public class DiaryPaintingImageGenerationStatusListConverter implements AttributeConverter<List<DiaryPaintingImageGenerationStatus>, String> {
+
+    private static final String EMPTY_LIST_STRING = "";
+
+    @Override
+    public String convertToDatabaseColumn(List<DiaryPaintingImageGenerationStatus> attribute) {
+        if (isAttributeEmpty(attribute)) {
+            return EMPTY_LIST_STRING;
+        }
+
+        try {
+            return attribute.stream()
+                    .map(DiaryPaintingImageGenerationStatus::name)
+                    .collect(Collectors.joining(","));
+        } catch (Exception e) {
+            throw new ConversionException("Error converting List<DiaryImageGenerationStatus> to String", e);
+        }
+    }
+
+    @Override
+    public List<DiaryPaintingImageGenerationStatus> convertToEntityAttribute(String dbData) {
+        if (isDBColumnEmpty(dbData)) {
+            return List.of();
+        }
+
+        try {
+            return Arrays.stream(dbData.split(","))
+                    .map(DiaryPaintingImageGenerationStatus::valueOf)
+                    .toList();
+        } catch (IllegalArgumentException e) {
+            throw new ConversionException("Error converting String to List<DiaryImageGenerationStatus>", e);
+        }
+    }
+
+    private static boolean isAttributeEmpty(List<DiaryPaintingImageGenerationStatus> attribute) {
+        return attribute == null || attribute.isEmpty();
+    }
+
+    private static boolean isDBColumnEmpty(String dbData) {
+        return dbData == null || dbData.isEmpty();
+    }
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -3,6 +3,7 @@ package com.startingblue.fourtooncookie.diary.service;
 import com.startingblue.fourtooncookie.character.domain.Character;
 import com.startingblue.fourtooncookie.character.service.CharacterService;
 import com.startingblue.fourtooncookie.diary.domain.Diary;
+import com.startingblue.fourtooncookie.diary.domain.DiaryPaintingImageGenerationStatus;
 import com.startingblue.fourtooncookie.diary.domain.DiaryRepository;
 import com.startingblue.fourtooncookie.diary.domain.DiaryStatus;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
@@ -34,6 +35,7 @@ public class DiaryService {
 
     private static final int MIN_PAINTING_IMAGE_POSITION = 0;
     private static final int MAX_PAINTING_IMAGE_POSITION = 3;
+    private static final int MAX_PAINTING_IMAGE_SIZE = 4;
 
     private final DiaryRepository diaryRepository;
     private final MemberService memberService;
@@ -58,6 +60,7 @@ public class DiaryService {
                 .isFavorite(false)
                 .diaryDate(request.diaryDate())
                 .paintingImageUrls(Collections.emptyList())
+                .paintingImageGenerationStatuses(new ArrayList<>(Collections.nCopies(MAX_PAINTING_IMAGE_SIZE, DiaryPaintingImageGenerationStatus.GENERATING)))
                 .status(DiaryStatus.IN_PROGRESS)
                 .character(character)
                 .memberId(member.getId())

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -3,7 +3,6 @@ package com.startingblue.fourtooncookie.diary.service;
 import com.startingblue.fourtooncookie.character.domain.Character;
 import com.startingblue.fourtooncookie.character.service.CharacterService;
 import com.startingblue.fourtooncookie.diary.domain.Diary;
-import com.startingblue.fourtooncookie.diary.domain.DiaryPaintingImageGenerationStatus;
 import com.startingblue.fourtooncookie.diary.domain.DiaryRepository;
 import com.startingblue.fourtooncookie.diary.domain.DiaryStatus;
 import com.startingblue.fourtooncookie.diary.dto.request.DiarySaveRequest;
@@ -35,7 +34,6 @@ public class DiaryService {
 
     private static final int MIN_PAINTING_IMAGE_POSITION = 0;
     private static final int MAX_PAINTING_IMAGE_POSITION = 3;
-    private static final int MAX_PAINTING_IMAGE_SIZE = 4;
 
     private final DiaryRepository diaryRepository;
     private final MemberService memberService;
@@ -60,7 +58,6 @@ public class DiaryService {
                 .isFavorite(false)
                 .diaryDate(request.diaryDate())
                 .paintingImageUrls(Collections.emptyList())
-                .paintingImageGenerationStatuses(new ArrayList<>(Collections.nCopies(MAX_PAINTING_IMAGE_SIZE, DiaryPaintingImageGenerationStatus.GENERATING)))
                 .status(DiaryStatus.IN_PROGRESS)
                 .character(character)
                 .memberId(member.getId())
@@ -70,7 +67,9 @@ public class DiaryService {
     @Transactional(readOnly = true)
     public Diary readDiaryById(final Long diaryId) {
         Optional<Diary> foundDiary = diaryRepository.findById(diaryId);
-        applyPreSignedUrls(foundDiary.get());
+        List<URL> preSignedUrls = generatePreSignedUrls(foundDiary.get().getId());
+
+        foundDiary.get().updatePaintingImageUrls(preSignedUrls);
         return foundDiary.get();
     }
 
@@ -83,7 +82,8 @@ public class DiaryService {
         );
 
         return diaries.getContent().stream().map(savedDiary -> {
-            applyPreSignedUrls(savedDiary);
+            List<URL> preSignedUrls = generatePreSignedUrls(savedDiary.getId());
+            savedDiary.updatePaintingImageUrls(preSignedUrls);
             return savedDiary;
         }).collect(Collectors.toList());
     }
@@ -145,14 +145,6 @@ public class DiaryService {
 
     public void deleteDiaryByMemberId(UUID memberId) {
         diaryRepository.deleteByMemberId(memberId);
-    }
-
-    private void applyPreSignedUrls(Diary savedDiary) {
-        List<URL> paintingImageUrls = Collections.emptyList();
-        if (savedDiary.isCompletedDiary()) {
-            paintingImageUrls = generatePreSignedUrls(savedDiary.getId());
-        }
-        savedDiary.updatePaintingImageUrls(paintingImageUrls);
     }
 
 }

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
@@ -166,26 +166,6 @@ class DiaryServiceTest {
         assertThat(updatedDiary.isFavorite()).isTrue();
     }
 
-    @DisplayName("저장된 모든 일기를 페이지네이션하여 가져온다.")
-    @Test
-    void readDiariesByMemberIdTest() throws MalformedURLException {
-        // given
-        LocalDate now = LocalDate.now();
-        List<Diary> diaries = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            diaries.add(createDiary(now.minusDays(i), character, member));
-        }
-        diaryRepository.saveAll(diaries);
-
-        // when
-        List<Diary> foundDiaries = diaryService.readDiariesByMemberId(member.getId(), 0, 3);
-
-        // then
-        assertThat(foundDiaries).hasSize(3);
-        assertThat(foundDiaries.get(0).getDiaryDate()).isEqualTo(now);
-        assertThat(foundDiaries.get(2).getDiaryDate()).isEqualTo(now.minusDays(2));
-    }
-
     @DisplayName("같은 날짜에 중복 일기를 작성하면 예외가 발생한다.")
     @Test
     void duplicateDiaryTest() throws MalformedURLException {


### PR DESCRIPTION
# [feat] DiaryPaintingImageStatus 추가
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-411
---
* 구현 내용
- DiaryPaintingImageStatus.enum 추가
- DiaryPaintingImageGenerationStatusListConverter 추가 (반정규화)
- DiaryService 의 buildDiary 메서드 변경 - paintingImageGenerationStatuses 생성자  추가 
    - 기본 사이즈 4개 및 `GENERATING`로 채움 
```java
private static final int MAX_PAINTING_IMAGE_SIZE = 4;

private Diary buildDiary(DiarySaveRequest request, Member member, Character character) {
    return Diary.builder()
            .content(request.content())
            .isFavorite(false)
            .diaryDate(request.diaryDate())
            .paintingImageUrls(Collections.emptyList())
            .paintingImageGenerationStatuses(new ArrayList<>(Collections.nCopies(MAX_PAINTING_IMAGE_SIZE, DiaryPaintingImageGenerationStatus.GENERATING)))
            .status(DiaryStatus.IN_PROGRESS)
            .character(character)
            .memberId(member.getId())
            .build();
}
```


* 추가 발생한 문제(논의 사항)
