### PR TITLE
[feat] 일기 삭제 또는 회원 탈퇴 시 생성된 만화 s3에서 제거

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -74,7 +74,7 @@ public class DiaryController {
 
     @DeleteMapping("/{diaryId}")
     public ResponseEntity<HttpStatus> deleteDiary(@PathVariable final Long diaryId) {
-        diaryService.deleteDiary(diaryId);
+        diaryService.deleteDiaryById(diaryId);
         return noContent().build();
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryRepository.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/domain/DiaryRepository.java
@@ -3,12 +3,16 @@ package com.startingblue.fourtooncookie.diary.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findAllByMemberIdOrderByDiaryDateDesc(UUID memberId, Pageable pageable);
     boolean existsByMemberIdAndDiaryDate(UUID memberId, LocalDate diaryDate);
-    void deleteByMemberId(UUID memberId);
+    @Query("SELECT d.id FROM Diary d WHERE d.memberId = :memberId")
+    List<Long> findDiaryIdsByMemberId(@Param("memberId") UUID memberId);
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryS3Service.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryS3Service.java
@@ -1,7 +1,6 @@
 package com.startingblue.fourtooncookie.diary.service;
 
 import com.startingblue.fourtooncookie.aws.s3.service.S3Service;
-import com.startingblue.fourtooncookie.diary.domain.Diary;
 import com.startingblue.fourtooncookie.global.converter.image.ImageConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,8 +42,11 @@ public class DiaryS3Service {
         return s3Service.getImageFromS3(bucketName, getKeyName(diaryId, gridPosition, IMAGE_PNG_FORMAT));
     }
 
-    private String getKeyName(Long diaryId,  int gridPosition, String imageFormat) {
+    private String getKeyName(Long diaryId, int gridPosition, String imageFormat) {
         return String.format("%s/%s.%s", diaryId, gridPosition, imageFormat);
     }
 
+    public void deleteImagesByDiaryId(Long diaryId) {
+        s3Service.deleteObjectsInFolder(bucketName, String.valueOf(diaryId));
+    }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -125,14 +125,6 @@ public class DiaryService {
         diaryRepository.delete(foundDiary);
     }
 
-    public void deleteDiariesByMemberId(UUID memberId) {
-        List<Long> diaryIds = diaryRepository.findDiaryIdsByMemberId(memberId);
-        for(Long diaryId : diaryIds) {
-            diaryS3Service.deleteImagesByDiaryId(diaryId);
-            diaryRepository.deleteById(diaryId);
-        }
-    }
-
     @Transactional(readOnly = true)
     public Diary readById(final Long id) {
         return diaryRepository.findById(id)

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -121,6 +121,7 @@ public class DiaryService {
 
     public void deleteDiary(Long diaryId) {
         Diary foundDiary = readById(diaryId);
+        diaryS3Service.deleteImagesByDiaryId(diaryId);
         diaryRepository.delete(foundDiary);
     }
 
@@ -146,5 +147,4 @@ public class DiaryService {
     public void deleteDiaryByMemberId(UUID memberId) {
         diaryRepository.deleteByMemberId(memberId);
     }
-
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryService.java
@@ -119,10 +119,18 @@ public class DiaryService {
         diaryImageGenerationLambdaInvoker.invokeDiaryImageGenerationLambda(existedDiary, character);
     }
 
-    public void deleteDiary(Long diaryId) {
+    public void deleteDiaryById(Long diaryId) {
         Diary foundDiary = readById(diaryId);
         diaryS3Service.deleteImagesByDiaryId(diaryId);
         diaryRepository.delete(foundDiary);
+    }
+
+    public void deleteDiariesByMemberId(UUID memberId) {
+        List<Long> diaryIds = diaryRepository.findDiaryIdsByMemberId(memberId);
+        for(Long diaryId : diaryIds) {
+            diaryS3Service.deleteImagesByDiaryId(diaryId);
+            diaryRepository.deleteById(diaryId);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -142,9 +150,5 @@ public class DiaryService {
     public boolean verifyDiaryOwner(UUID memberId, Long diaryId) {
         Diary foundDiary = readById(diaryId);
         return foundDiary.isOwner(memberId);
-    }
-
-    public void deleteDiaryByMemberId(UUID memberId) {
-        diaryRepository.deleteByMemberId(memberId);
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
@@ -1,13 +1,16 @@
 package com.startingblue.fourtooncookie.member;
 
-import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import com.startingblue.fourtooncookie.member.dto.request.MemberSaveRequest;
 import com.startingblue.fourtooncookie.member.dto.response.MemberSavedResponse;
 import com.startingblue.fourtooncookie.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
@@ -16,7 +19,6 @@ import java.util.UUID;
 public final class MemberController {
 
     private final MemberService memberService;
-    private final DiaryService diaryService;
 
     @GetMapping("/member")
     public ResponseEntity<MemberSavedResponse> readMember(UUID memberId) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
@@ -33,7 +33,6 @@ public final class MemberController {
     @DeleteMapping("/member")
     public ResponseEntity<HttpStatus> hardDeleteMember(UUID memberId) {
         memberService.hardDeleteById(memberId);
-        diaryService.deleteDiaryByMemberId(memberId);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
@@ -1,0 +1,27 @@
+package com.startingblue.fourtooncookie.member.service;
+
+import com.startingblue.fourtooncookie.diary.domain.DiaryRepository;
+import com.startingblue.fourtooncookie.diary.service.DiaryS3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberDiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final DiaryS3Service diaryS3Service;
+
+    public void deleteDiariesByMemberId(UUID memberId) {
+        List<Long> diaryIds = diaryRepository.findDiaryIdsByMemberId(memberId);
+        for (Long diaryId : diaryIds) {
+            diaryS3Service.deleteImagesByDiaryId(diaryId);
+            diaryRepository.deleteById(diaryId);
+        }
+    }
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.startingblue.fourtooncookie.member.service;
 
+import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import com.startingblue.fourtooncookie.member.domain.Member;
 import com.startingblue.fourtooncookie.member.domain.MemberRepository;
 import com.startingblue.fourtooncookie.member.domain.Role;
@@ -10,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -19,6 +19,7 @@ import java.util.UUID;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final DiaryService diaryService;
 
     public void save(UUID memberId, MemberSaveRequest memberSaveRequest) {
         if (verifyMemberExists(memberId)) {
@@ -40,6 +41,7 @@ public class MemberService {
     }
 
     public void hardDeleteById(UUID memberId) {
+        diaryService.deleteDiariesByMemberId(memberId);
         memberRepository.deleteById(memberId);
     }
 
@@ -56,5 +58,4 @@ public class MemberService {
         Member member = readById(memberId);
         return member.isAdmin();
     }
-
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.startingblue.fourtooncookie.member.service;
 
-import com.startingblue.fourtooncookie.diary.service.DiaryService;
 import com.startingblue.fourtooncookie.member.domain.Member;
 import com.startingblue.fourtooncookie.member.domain.MemberRepository;
 import com.startingblue.fourtooncookie.member.domain.Role;
@@ -19,12 +18,12 @@ import java.util.UUID;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final DiaryService diaryService;
+    private final MemberDiaryService memberDiaryService;
 
     public void save(UUID memberId, MemberSaveRequest memberSaveRequest) {
         if (verifyMemberExists(memberId)) {
             throw new MemberDuplicateException("Member with id " + memberId + " already exists");
-        };
+        }
 
         Member member = Member.builder()
                 .id(memberId)
@@ -37,11 +36,11 @@ public class MemberService {
     }
 
     public Member readById(UUID memberId) {
-        return  memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
     }
 
     public void hardDeleteById(UUID memberId) {
-        diaryService.deleteDiariesByMemberId(memberId);
+        memberDiaryService.deleteDiariesByMemberId(memberId);
         memberRepository.deleteById(memberId);
     }
 

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
@@ -81,13 +81,13 @@ class DiaryServiceTest {
 
     @DisplayName("저장된 일기를 삭제한다.")
     @Test
-    void deleteDiaryTest() throws MalformedURLException {
+    void deleteDiaryByIdTest() throws MalformedURLException {
         // given
         Diary diary = createDiary(LocalDate.of(2024, 7, 21), character, member);
         diaryRepository.save(diary);
 
         // when
-        diaryService.deleteDiary(diary.getId());
+        diaryService.deleteDiaryById(diary.getId());
 
         // then
         boolean exists = diaryRepository.existsById(diary.getId());
@@ -129,7 +129,7 @@ class DiaryServiceTest {
         Long notExistingId = -1L;
 
         // when & then
-        assertThatThrownBy(() -> diaryService.deleteDiary(notExistingId));
+        assertThatThrownBy(() -> diaryService.deleteDiaryById(notExistingId));
 
         boolean exists = diaryRepository.existsById(diary.getId());
         assertThat(exists).isTrue();


### PR DESCRIPTION
# [feat] 일기 삭제 또는 회원 탈퇴 시 생성된 만화 s3에서 제거
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-412
---
* 구현 내용
일기 삭제 또는 회원 탈퇴 시 생성된 만화 s3에서 제거되며, 시기는 즉시입니다.
순환참조를 제거하기 위해 별도의 서비스 객체를 두었습니다.

* 추가 발생한 문제(논의 사항)
