### PR TITLE
[fix] 지원하지 않는 accept language 헤더 제거

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/LocaleConfig.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/LocaleConfig.java
@@ -1,7 +1,6 @@
 package com.startingblue.fourtooncookie.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.LocaleResolver;
@@ -16,7 +15,7 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public class LocaleConfig implements WebMvcConfigurer {
 
-    private static final List<Locale> SUPPORTED_LOCALES = List.of(Locale.KOREAN, Locale.KOREA);
+    private static final List<Locale> SUPPORTED_LOCALES = List.of(Locale.KOREAN);
 
     @Bean
     public LocaleResolver localeResolver() {


### PR DESCRIPTION
# [fix] 지원하지 않는 accept language 헤더 제거
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-
---
* 구현 내용
<img width="666" alt="스크린샷 2024-10-18 오후 12 51 09" src="https://github.com/user-attachments/assets/dcb6b7d0-706a-4dd0-b73e-d1b4cb23488f">

Accept-Language 헤더 "ko" "en"만 지원하므로 "ko-KR"(KOREA)은 제거

* 추가 발생한 문제(논의 사항)
