### PR TITLE
[feat] Translation(국제화 테이블) 구현

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
@@ -5,6 +5,7 @@ import com.startingblue.fourtooncookie.artwork.dto.ArtworkSaveRequest;
 import com.startingblue.fourtooncookie.artwork.dto.ArtworkUpdateRequest;
 import com.startingblue.fourtooncookie.artwork.exception.ArtworkDuplicateException;
 import com.startingblue.fourtooncookie.artwork.exception.ArtworkNotFoundException;
+import com.startingblue.fourtooncookie.artwork.service.ArtworkTranslationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ import java.util.Optional;
 public class ArtworkService {
 
     private final ArtworkRepository artworkRepository;
-    private final MessageSource xmlMessageSource;
+    private final ArtworkTranslationService artworkTranslationService;
 
     public void createArtwork(ArtworkSaveRequest request) {
         verifyUniqueArtwork(request.title(), request.thumbnailUrl());
@@ -37,7 +38,7 @@ public class ArtworkService {
     @Transactional(readOnly = true)
     public List<Artwork> readAllArtworks(Locale locale) {
         return readAllArtworks().stream()
-                .map(artwork -> getArtworkWithNameChange(artwork, locale))
+                .map(artwork -> artworkTranslationService.translateArtwork(artwork.clone(), locale))
                 .toList();
     }
 
@@ -59,6 +60,14 @@ public class ArtworkService {
     }
 
     @Transactional(readOnly = true)
+    public Artwork readById(Long artworkId, Locale locale) {
+        return artworkTranslationService.translateArtwork(
+                readById(artworkId).clone(),
+                locale
+        );
+    }
+
+    @Transactional(readOnly = true)
     public void verifyUniqueArtwork(String title, URL thumbnailUrl) {
         if (artworkRepository.existsByTitle(title)) {
             throw new ArtworkDuplicateException("Artwork with title '" + title + "' already exists.");
@@ -66,14 +75,6 @@ public class ArtworkService {
         if (artworkRepository.existsByThumbnailUrl(thumbnailUrl)) {
             throw new ArtworkDuplicateException("Artwork with thumbnail URL '" + thumbnailUrl + "' already exists.");
         }
-    }
-
-    public Artwork getArtworkWithNameChange(Artwork artwork, Locale locale) {
-        return new Artwork(artwork.getId(), getLocalizedArtworkTitle(artwork.getId(), locale), artwork.getThumbnailUrl());
-    }
-
-    public String getLocalizedArtworkTitle(Long artworkId, Locale locale) {
-        return Objects.requireNonNull(xmlMessageSource.getMessage("artwork.name." + artworkId, null, locale));
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
@@ -38,7 +38,7 @@ public class ArtworkService {
     @Transactional(readOnly = true)
     public List<Artwork> readAllArtworks(Locale locale) {
         return readAllArtworks().stream()
-                .map(artwork -> artworkTranslationService.translateArtwork(artwork.clone(), locale))
+                .map(artwork -> artworkTranslationService.translateArtwork(artwork, locale))
                 .toList();
     }
 
@@ -62,7 +62,7 @@ public class ArtworkService {
     @Transactional(readOnly = true)
     public Artwork readById(Long artworkId, Locale locale) {
         return artworkTranslationService.translateArtwork(
-                readById(artworkId).clone(),
+                readById(artworkId),
                 locale
         );
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/domain/Artwork.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/domain/Artwork.java
@@ -1,11 +1,13 @@
 package com.startingblue.fourtooncookie.artwork.domain;
 
+import com.startingblue.fourtooncookie.translation.annotation.TranslatableField;
 import jakarta.persistence.*;
 import jakarta.validation.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import java.util.Set;
 @Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Artwork {
 
     @Id
@@ -27,6 +30,7 @@ public class Artwork {
 
     @NotBlank(message = "작품명은 필수 입니다.")
     @Size(min = 1, max = 255, message = "작품명의 글자수는 1에서 255자 이내여야 합니다.")
+    @TranslatableField
     private String title;
 
     @NotNull(message = "작품 썸네일 URL이 존재해야 합니다.")
@@ -37,12 +41,6 @@ public class Artwork {
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
         validate();
-    }
-
-    public Artwork(final Long id, final String title, final URL thumbnailUrl) {
-        this.id = id;
-        this.title = title;
-        this.thumbnailUrl = thumbnailUrl;
     }
 
     public void update(final String title, final URL thumbnailUrl) {
@@ -71,5 +69,10 @@ public class Artwork {
     @Override
     public int hashCode() {
         return Objects.hash(id, title, thumbnailUrl);
+    }
+
+    @Override
+    public Artwork clone() {
+        return new Artwork(id, title, thumbnailUrl);
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/domain/Artwork.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/domain/Artwork.java
@@ -71,8 +71,4 @@ public class Artwork {
         return Objects.hash(id, title, thumbnailUrl);
     }
 
-    @Override
-    public Artwork clone() {
-        return new Artwork(id, title, thumbnailUrl);
-    }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
@@ -1,0 +1,20 @@
+package com.startingblue.fourtooncookie.artwork.service;
+
+import com.startingblue.fourtooncookie.artwork.domain.Artwork;
+import com.startingblue.fourtooncookie.translation.TranslationService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+@AllArgsConstructor
+public class ArtworkTranslationService {
+
+    private final TranslationService translationService;
+
+    public Artwork translateArtwork(Artwork artwork, Locale locale) {
+        return translationService.getTranslatedObject(artwork, locale);
+    }
+
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
@@ -14,7 +14,7 @@ public class ArtworkTranslationService {
     private final TranslationService translationService;
 
     public Artwork translateArtwork(Artwork artwork, Locale locale) {
-        return translationService.getTranslatedObject(artwork, locale);
+        return translationService.getTranslatedObject(artwork.clone(), locale);
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/service/ArtworkTranslationService.java
@@ -4,6 +4,7 @@ import com.startingblue.fourtooncookie.artwork.domain.Artwork;
 import com.startingblue.fourtooncookie.translation.TranslationService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
 
@@ -13,8 +14,9 @@ public class ArtworkTranslationService {
 
     private final TranslationService translationService;
 
+    @Transactional(readOnly = true)
     public Artwork translateArtwork(Artwork artwork, Locale locale) {
-        return translationService.getTranslatedObject(artwork.clone(), locale);
+        return translationService.getTranslatedObject(artwork, locale);
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -9,6 +9,7 @@ import com.startingblue.fourtooncookie.character.dto.CharacterUpdateRequest;
 import com.startingblue.fourtooncookie.character.exception.CharacterDuplicateException;
 import com.startingblue.fourtooncookie.character.exception.CharacterNotFoundException;
 import com.startingblue.fourtooncookie.character.service.CharacterArtworkService;
+import com.startingblue.fourtooncookie.character.service.CharacterTranslationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,7 @@ public class CharacterService {
 
     private final CharacterRepository characterRepository;
     private final CharacterArtworkService characterArtworkService;
-    private final MessageSource xmlMessageSource;
+    private final CharacterTranslationService characterTranslationService;
 
     public void createCharacter(final CharacterSaveRequest request) {
         CharacterVisionType visionType = findByCharacterVisionType(request.characterVisionType());
@@ -51,7 +52,7 @@ public class CharacterService {
     @Transactional(readOnly = true)
     public List<Character> readAllCharacters(Locale locale) {
         return readAllCharacters().stream()
-                .map(character -> localizeCharacter(character, locale))
+                .map(character -> characterTranslationService.translateCharacter(character, locale))
                 .toList();
     }
 
@@ -82,30 +83,7 @@ public class CharacterService {
     @Transactional(readOnly = true)
     public Character readById(Long characterId, Locale locale) {
         Character foundCharacter = readById(characterId);
-        return localizeCharacter(foundCharacter, locale);
-    }
-
-    private Character localizeCharacter(Character character, Locale locale) {
-        Artwork localizedArtwork = characterArtworkService.readById(character.getArtwork().getId(), locale);
-
-        String localizedCharacterName = getLocalizedCharacterName(character.getId(), locale);
-        return getCharacterWithNameChangeAndArtworkChange(character, localizedCharacterName, localizedArtwork);
-    }
-
-    private Character getCharacterWithNameChangeAndArtworkChange(Character character, String localizedName, Artwork localizedArtwork ) {
-        return Character.builder()
-                .id(character.getId())
-                .characterVisionType(character.getCharacterVisionType())
-                .paymentType(character.getPaymentType())
-                .name(localizedName)
-                .artwork(localizedArtwork)
-                .selectionThumbnailUrl(character.getSelectionThumbnailUrl())
-                .basePrompt(character.getBasePrompt())
-                .build();
-    }
-
-    public String getLocalizedCharacterName(Long characterId, Locale locale) {
-        return Objects.requireNonNull(xmlMessageSource.getMessage("character.name." + characterId, null, locale));
+        return characterTranslationService.translateCharacter(foundCharacter, locale);
     }
 
     private CharacterVisionType findByCharacterVisionType(CharacterVisionType characterVisionType) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -86,7 +86,7 @@ public class CharacterService {
     }
 
     private Character localizeCharacter(Character character, Locale locale) {
-        Artwork localizedArtwork = characterArtworkService.getArtworkWithNameChange(character.getArtwork(), locale);
+        Artwork localizedArtwork = characterArtworkService.readById(character.getArtwork().getId(), locale);
 
         String localizedCharacterName = getLocalizedCharacterName(character.getId(), locale);
         return getCharacterWithNameChangeAndArtworkChange(character, localizedCharacterName, localizedArtwork);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/domain/Character.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/domain/Character.java
@@ -1,6 +1,7 @@
 package com.startingblue.fourtooncookie.character.domain;
 
 import com.startingblue.fourtooncookie.artwork.domain.Artwork;
+import com.startingblue.fourtooncookie.translation.annotation.TranslatableField;
 import jakarta.persistence.*;
 import jakarta.validation.*;
 import jakarta.validation.constraints.NotBlank;
@@ -42,6 +43,7 @@ public class Character {
 
     @NotBlank(message = "캐릭터 이름은 필수 입니다.")
     @Size(min = 1, max = 255, message = "캐릭터 이름은 1자 이상 255자 이내여야 합니다.")
+    @TranslatableField
     private String name;
 
     @NotNull(message = "캐릭터 선택 썸네일 URL은 필수 입니다.")

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/domain/Character.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/domain/Character.java
@@ -17,7 +17,7 @@ import java.util.Set;
 @Slf4j
 @Table(name = "`character`")
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Character {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
@@ -16,8 +16,4 @@ public class CharacterArtworkService {
     public Artwork readById(Long artworkId) {
         return artworkService.readById(artworkId);
     }
-
-    public Artwork readById(Long artworkId, Locale locale) {
-        return artworkService.readById(artworkId, locale);
-    }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
@@ -17,8 +17,7 @@ public class CharacterArtworkService {
         return artworkService.readById(artworkId);
     }
 
-
-    public Artwork getArtworkWithNameChange(Artwork artwork, Locale locale) {
-        return artworkService.getArtworkWithNameChange(artwork, locale);
+    public Artwork readById(Long artworkId, Locale locale) {
+        return artworkService.readById(artworkId, locale);
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
@@ -5,6 +5,7 @@ import com.startingblue.fourtooncookie.character.domain.Character;
 import com.startingblue.fourtooncookie.translation.TranslationService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
 
@@ -14,8 +15,9 @@ public class CharacterTranslationService {
 
     private final TranslationService translationService;
 
+    @Transactional(readOnly = true)
     public Character translateCharacter(Character character, Locale locale) {
-        Artwork localizedArtwork = translationService.getTranslatedObject(character.getArtwork().clone(), locale);
+        Artwork localizedArtwork = translationService.getTranslatedObject(character.getArtwork(), locale);
 
         Character clonedCharacter = character.toBuilder()
                 .artwork(localizedArtwork)

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
@@ -1,0 +1,28 @@
+package com.startingblue.fourtooncookie.character.service;
+
+import com.startingblue.fourtooncookie.artwork.domain.Artwork;
+import com.startingblue.fourtooncookie.character.domain.Character;
+import com.startingblue.fourtooncookie.translation.TranslationService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+@AllArgsConstructor
+public class CharacterTranslationService {
+
+    private final TranslationService translationService;
+    private final CharacterArtworkService characterArtworkService;
+
+    public Character translateCharacter(Character character, Locale locale) {
+        Artwork localizedArtwork = characterArtworkService.readById(character.getArtwork().getId(), locale);
+
+        Character clonedCharacter = character.toBuilder()
+                .artwork(localizedArtwork)
+                .build();
+
+        return translationService.getTranslatedObject(clonedCharacter, locale);
+    }
+
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterTranslationService.java
@@ -13,10 +13,9 @@ import java.util.Locale;
 public class CharacterTranslationService {
 
     private final TranslationService translationService;
-    private final CharacterArtworkService characterArtworkService;
 
     public Character translateCharacter(Character character, Locale locale) {
-        Artwork localizedArtwork = characterArtworkService.readById(character.getArtwork().getId(), locale);
+        Artwork localizedArtwork = translationService.getTranslatedObject(character.getArtwork().clone(), locale);
 
         Character clonedCharacter = character.toBuilder()
                 .artwork(localizedArtwork)

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationRepository.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationRepository.java
@@ -1,0 +1,9 @@
+package com.startingblue.fourtooncookie.translation;
+
+import com.startingblue.fourtooncookie.translation.domain.Translation;
+import com.startingblue.fourtooncookie.translation.domain.TranslationId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TranslationRepository extends JpaRepository<Translation, TranslationId> {
+    boolean existsById(TranslationId translationId);
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
@@ -1,0 +1,100 @@
+package com.startingblue.fourtooncookie.translation;
+
+import com.startingblue.fourtooncookie.translation.annotation.TranslatableField;
+import com.startingblue.fourtooncookie.translation.domain.Translation;
+import com.startingblue.fourtooncookie.translation.domain.TranslationId;
+import com.startingblue.fourtooncookie.translation.exception.TranslationDuplicateException;
+import com.startingblue.fourtooncookie.translation.exception.TranslationNotFoundException;
+import com.startingblue.fourtooncookie.translation.exception.TranslationObjectClassIdNotFoundException;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Locale;
+
+@Service
+@AllArgsConstructor
+public class TranslationService {
+
+    private final TranslationRepository translationRepository;
+
+    public <T> T getTranslatedObject(T object, Locale locale) {
+        String className = getClassName(object);
+        Long classId = getClassId(object);
+
+        Arrays.stream(object.getClass().getDeclaredFields())
+            .filter(field -> field.isAnnotationPresent(TranslatableField.class))
+            .forEach(field -> {
+                try {
+                    field.setAccessible(true);
+
+                    String fieldName = camelToSnake(field.getName());
+                    Object fieldValue = field.get(object);
+
+                    if (!(fieldValue instanceof String))
+                        return;
+
+                    String translatedValue = getTranslationContent(className, fieldName, classId, locale);
+
+                    field.set(object, translatedValue);
+                } catch (Exception ignored) {}
+            });
+
+        return object;
+    }
+
+    private String getClassName(Object object) {
+        return camelToSnake(object.getClass().getSimpleName());
+    }
+
+    private Long getClassId(Object object) {
+        try {
+            return (Long) Arrays.stream(object.getClass().getDeclaredFields())
+                    .filter(field -> field.isAnnotationPresent(Id.class))
+                    .findFirst().get().get(object);
+        } catch (Exception e) {
+            throw new TranslationObjectClassIdNotFoundException();
+        }
+    }
+
+    private String camelToSnake(String camelCaseStr) {
+        return camelCaseStr.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+    }
+
+    public String getTranslationContent(TranslationId translationId) {
+        Translation translation = translationRepository.findById(translationId)
+                .orElseThrow(TranslationNotFoundException::new);
+
+        return translation.getContent();
+    }
+
+    public String getTranslationContent(String className, String fieldName, Long classId, Locale locale) {
+        return getTranslationContent(new TranslationId(className, fieldName, classId, locale));
+    }
+
+    public void addTranslation(Object object, String fieldName, Locale locale, String content) {
+        String className = getClassName(object);
+        Long classId = getClassId(object);
+
+        TranslationId translationId = new TranslationId(className, fieldName, classId, locale);
+
+        if (! isTranslationExists(translationId)){
+            throw new TranslationDuplicateException();
+        }
+
+        Translation translation = Translation.builder()
+                .translationId(translationId)
+                .content(content)
+                .build();
+
+        translationRepository.save(translation);
+    }
+
+    private boolean isTranslationExists(TranslationId translationId) {
+        return translationRepository.existsById(translationId);
+    }
+
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
@@ -8,10 +8,8 @@ import com.startingblue.fourtooncookie.translation.exception.TranslationNotFound
 import com.startingblue.fourtooncookie.translation.exception.TranslationObjectClassIdNotFoundException;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
-import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Locale;
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @AllArgsConstructor
@@ -19,7 +20,7 @@ public class TranslationService {
 
     private final TranslationRepository translationRepository;
 
-    private static final Map<String, List<Field>> cachedTranslatableField = new HashMap<>();
+    private static final Map<String, List<Field>> cachedTranslatableField = new ConcurrentHashMap<>();
 
     public <T> T getTranslatedObject(T object, Locale locale) {
         getTranslatableFields(object).forEach(field -> {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/TranslationService.java
@@ -20,46 +20,25 @@ public class TranslationService {
     private final TranslationRepository translationRepository;
 
     public <T> T getTranslatedObject(T object, Locale locale) {
-        String className = getClassName(object);
-        Long classId = getClassId(object);
-
         Arrays.stream(object.getClass().getDeclaredFields())
             .filter(field -> field.isAnnotationPresent(TranslatableField.class))
             .forEach(field -> {
                 try {
                     field.setAccessible(true);
 
-                    String fieldName = camelToSnake(field.getName());
+                    String fieldName = field.getName();
                     Object fieldValue = field.get(object);
 
                     if (!(fieldValue instanceof String))
                         return;
 
-                    String translatedValue = getTranslationContent(className, fieldName, classId, locale);
+                    String translatedValue = getTranslationContent(object, fieldName, locale);
 
                     field.set(object, translatedValue);
                 } catch (Exception ignored) {}
             });
 
         return object;
-    }
-
-    private String getClassName(Object object) {
-        return camelToSnake(object.getClass().getSimpleName());
-    }
-
-    private Long getClassId(Object object) {
-        try {
-            return (Long) Arrays.stream(object.getClass().getDeclaredFields())
-                    .filter(field -> field.isAnnotationPresent(Id.class))
-                    .findFirst().get().get(object);
-        } catch (Exception e) {
-            throw new TranslationObjectClassIdNotFoundException();
-        }
-    }
-
-    private String camelToSnake(String camelCaseStr) {
-        return camelCaseStr.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
     }
 
     public String getTranslationContent(TranslationId translationId) {
@@ -71,6 +50,12 @@ public class TranslationService {
 
     public String getTranslationContent(String className, String fieldName, Long classId, Locale locale) {
         return getTranslationContent(new TranslationId(className, fieldName, classId, locale));
+    }
+
+    public String getTranslationContent(Object object, String fieldName, Locale locale) {
+        String className = getClassName(object);
+        Long classId = getClassId(object);
+        return getTranslationContent(className, fieldName, classId, locale);
     }
 
     public void addTranslation(Object object, String fieldName, Locale locale, String content) {
@@ -93,6 +78,20 @@ public class TranslationService {
 
     private boolean isTranslationExists(TranslationId translationId) {
         return translationRepository.existsById(translationId);
+    }
+
+    private String getClassName(Object object) {
+        return object.getClass().getSimpleName();
+    }
+
+    private Long getClassId(Object object) {
+        try {
+            return (Long) Arrays.stream(object.getClass().getDeclaredFields())
+                    .filter(field -> field.isAnnotationPresent(Id.class))
+                    .findFirst().get().get(object);
+        } catch (Exception e) {
+            throw new TranslationObjectClassIdNotFoundException();
+        }
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/annotation/TranslatableField.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/annotation/TranslatableField.java
@@ -1,0 +1,12 @@
+package com.startingblue.fourtooncookie.translation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TranslatableField {
+
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
@@ -1,10 +1,12 @@
 package com.startingblue.fourtooncookie.translation.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.*;
 import lombok.*;
 import software.amazon.awssdk.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -39,7 +41,12 @@ public class Translation {
     }
 
     private void validate() {
-
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        Set<ConstraintViolation<Translation>> violations = validator.validate(this);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
     }
 
     @Override

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
@@ -1,0 +1,59 @@
+package com.startingblue.fourtooncookie.translation.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import software.amazon.awssdk.annotations.NotNull;
+
+import java.util.Objects;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Translation {
+
+    @EmbeddedId
+    @Column(name = "translation_id")
+    private TranslationId translationId;
+
+    @NotNull
+    private String content;
+
+    public void update(String content) {
+        this.content = content;
+
+        validate();
+    }
+
+    public static TranslationBuilder builder() {
+        return new CustomTranslationBuilder();
+    }
+
+    private static class CustomTranslationBuilder extends TranslationBuilder {
+        @Override
+        public Translation build() {
+            Translation translation = super.build();
+            translation.validate();
+            return translation;
+        }
+    }
+
+    private void validate() {
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Translation that = (Translation) o;
+        return translationId.equals(that.translationId)
+                && content.equals(that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(translationId, content);
+    }
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/Translation.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 public class Translation {
 
     @EmbeddedId
-    @Column(name = "translation_id")
     private TranslationId translationId;
 
     @NotNull

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/TranslationId.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/domain/TranslationId.java
@@ -1,0 +1,41 @@
+package com.startingblue.fourtooncookie.translation.domain;
+
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Locale;
+import java.util.Objects;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+public class TranslationId {
+
+    private String className;
+
+    private String fieldName;
+
+    private Long classId;
+
+    private Locale locale;
+
+    public TranslationId() {}
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TranslationId that = (TranslationId) o;
+        return (Objects.equals(className, that.className)
+                && Objects.equals(fieldName, that.fieldName)
+                && Objects.equals(classId, that.classId)
+                && Objects.equals(locale, that.locale));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, fieldName, classId, locale);
+    }
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationDuplicateException.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationDuplicateException.java
@@ -1,0 +1,8 @@
+package com.startingblue.fourtooncookie.translation.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class TranslationDuplicateException extends RuntimeException {
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationNotFoundException.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.startingblue.fourtooncookie.translation.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.NoSuchElementException;
+
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TranslationNotFoundException extends NoSuchElementException {
+}

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationObjectClassIdNotFoundException.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/translation/exception/TranslationObjectClassIdNotFoundException.java
@@ -1,0 +1,10 @@
+package com.startingblue.fourtooncookie.translation.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.NoSuchElementException;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TranslationObjectClassIdNotFoundException extends NoSuchElementException {
+}

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
@@ -79,8 +79,8 @@ class ArtworkServiceTest {
     void testReadAllArtworks() throws MalformedURLException {
         // Given
         List<Artwork> artworks = Arrays.asList(
-                new Artwork(1L, "Artwork 1", new URL("http://example.com/image1.jpg")),
-                new Artwork(2L, "Artwork 2", new URL("http://example.com/image2.jpg"))
+                new Artwork( "Artwork 1", new URL("http://example.com/image1.jpg")),
+                new Artwork( "Artwork 2", new URL("http://example.com/image2.jpg"))
         );
 
         when(artworkRepository.findAll()).thenReturn(artworks);
@@ -97,23 +97,14 @@ class ArtworkServiceTest {
     @Test
     @DisplayName("Artwork ID로 지역화된 이름을 가져온다")
     void testGetLocalizedArtworkTitle() {
-        // Given
-        Long artworkId = 1L;
-        when(xmlMessageSource.getMessage(anyString(), any(), eq(Locale.KOREAN)))
-                .thenReturn("Localized Artwork Title");
-
-        // When
-        String localizedTitle = artworkService.getLocalizedArtworkTitle(artworkId, Locale.KOREAN);
-
-        // Then
-        assertThat(localizedTitle).isEqualTo("Localized Artwork Title");
+        // TODO
     }
 
     @Test
     @DisplayName("Artwork 업데이트 성공")
     void testUpdateArtwork() throws MalformedURLException {
         // Given
-        Artwork existingArtwork = new Artwork(1L, "Old Title", new URL("http://example.com/old_image.jpg"));
+        Artwork existingArtwork = new Artwork("Old Title", new URL("http://example.com/old_image.jpg"));
         ArtworkUpdateRequest request = new ArtworkUpdateRequest("Updated Title", new URL("http://example.com/new_image.jpg"));
 
         when(artworkRepository.findById(1L)).thenReturn(Optional.of(existingArtwork));
@@ -144,7 +135,7 @@ class ArtworkServiceTest {
     @DisplayName("Artwork 삭제 성공")
     void testDeleteArtwork() throws MalformedURLException {
         // Given
-        Artwork artwork = new Artwork(1L, "Artwork", new URL("http://example.com/image.jpg"));
+        Artwork artwork = new Artwork("Artwork", new URL("http://example.com/image.jpg"));
         when(artworkRepository.findById(1L)).thenReturn(Optional.of(artwork));
 
         // When

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/TranslationServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/TranslationServiceTest.java
@@ -75,11 +75,8 @@ class TranslationServiceTest {
                 .build()
         );
 
-        SampleEntity sampleEntityInEnglish = translationService.getTranslatedObject(sampleEntity, Locale.ENGLISH);
-
-        SampleEntity sampleEntityInFrench = translationService.getTranslatedObject(sampleEntity, Locale.FRENCH);
-
         // then 1
+        SampleEntity sampleEntityInEnglish = translationService.getTranslatedObject(sampleEntity, Locale.ENGLISH);
         // Translatable Field가 변경되었는가
         assertThat(sampleEntityInEnglish.translatableField).isEqualTo(translatableFieldInEnglish);
         assertThat(sampleEntityInEnglish.translatableField2).isEqualTo(translatableField2InEnglish);
@@ -88,6 +85,7 @@ class TranslationServiceTest {
         assertThat(sampleEntityInEnglish.unTranslatableField2).isEqualTo(defaultField);
 
         // then 2
+        SampleEntity sampleEntityInFrench = translationService.getTranslatedObject(sampleEntity, Locale.FRENCH);
         // Translatable Field가 변경되었는가
         assertThat(sampleEntityInFrench.translatableField).isEqualTo(translatableFieldInFrench);
         assertThat(sampleEntityInFrench.translatableField2).isEqualTo(translatableField2InFrench);

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/TranslationServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/TranslationServiceTest.java
@@ -1,0 +1,215 @@
+package com.startingblue.fourtooncookie.translation;
+
+import com.startingblue.fourtooncookie.translation.domain.Translation;
+import com.startingblue.fourtooncookie.translation.domain.TranslationId;
+import com.startingblue.fourtooncookie.translation.exception.TranslationNotFoundException;
+import com.startingblue.fourtooncookie.translation.sample.SampleEntity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TranslationServiceTest {
+
+    @Autowired
+    private TranslationService translationService;
+
+    @Autowired
+    private TranslationRepository translationRepository;
+
+    @BeforeEach
+    void setUp() {
+        translationRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("언어 지원이 존재하는 경우에 번역이 성공하는가를 테스트")
+    @Test
+    void getTranslatedObject() {
+        // given
+        Long id = 1L;
+        String defaultField = "기본값";
+        String translatableFieldInEnglish = "english";
+        String translatableField2InEnglish = "english2";
+        String translatableFieldInFrench = "french";
+        String translatableField2InFrench = "french";
+        SampleEntity sampleEntity = new SampleEntity(id, defaultField, defaultField, defaultField, defaultField);
+
+        // when
+        String className = sampleEntity.getClass().getSimpleName();
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField", id, Locale.ENGLISH))
+                .content(translatableFieldInEnglish)
+                .build()
+        );
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField", id, Locale.FRENCH))
+                .content(translatableFieldInFrench)
+                .build()
+        );
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField2", id, Locale.ENGLISH))
+                .content(translatableField2InEnglish)
+                .build()
+        );
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField2", id, Locale.FRENCH))
+                .content(translatableField2InFrench)
+                .build()
+        );
+
+        SampleEntity sampleEntityInEnglish = translationService.getTranslatedObject(sampleEntity, Locale.ENGLISH);
+
+        SampleEntity sampleEntityInFrench = translationService.getTranslatedObject(sampleEntity, Locale.FRENCH);
+
+        // then 1
+        // Translatable Field가 변경되었는가
+        assertThat(sampleEntityInEnglish.translatableField).isEqualTo(translatableFieldInEnglish);
+        assertThat(sampleEntityInEnglish.translatableField2).isEqualTo(translatableField2InEnglish);
+        // un Translatable Field가 변경되지 않았는가
+        assertThat(sampleEntityInEnglish.unTranslatableField).isEqualTo(defaultField);
+        assertThat(sampleEntityInEnglish.unTranslatableField2).isEqualTo(defaultField);
+
+        // then 2
+        // Translatable Field가 변경되었는가
+        assertThat(sampleEntityInFrench.translatableField).isEqualTo(translatableFieldInFrench);
+        assertThat(sampleEntityInFrench.translatableField2).isEqualTo(translatableField2InFrench);
+        // un Translatable Field가 변경되지 않았는가
+        assertThat(sampleEntityInFrench.unTranslatableField).isEqualTo(defaultField);
+        assertThat(sampleEntityInFrench.unTranslatableField2).isEqualTo(defaultField);
+    }
+
+    @DisplayName("언어 지원이 존재하지 않는 경우에 번역이 안 되고 그대로 나오는가를 테스트")
+    @Test
+    void getTranslatedObjectDefault() {
+        // given
+        Long id = 1L;
+        String defaultField = "기본값";
+        String translatableFieldInEnglish = "english";
+        String translatableField2InEnglish = "english2";
+        SampleEntity sampleEntity = new SampleEntity(id, defaultField, defaultField, defaultField, defaultField);
+
+        // when
+        String className = sampleEntity.getClass().getSimpleName();
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField", id, Locale.ENGLISH))
+                .content(translatableFieldInEnglish)
+                .build()
+        );
+
+        translationRepository.save(Translation.builder()
+                .translationId(new TranslationId(className,  "translatableField2", id, Locale.ENGLISH))
+                .content(translatableField2InEnglish)
+                .build()
+        );
+
+        SampleEntity sampleEntityInFrench = translationService.getTranslatedObject(sampleEntity, Locale.FRENCH);
+
+        //then
+        // Translatable Field가 변경되었는가 (변경되지 않았어야 함)
+        assertThat(sampleEntityInFrench.translatableField).isEqualTo(defaultField);
+        assertThat(sampleEntityInFrench.translatableField2).isEqualTo(defaultField);
+        // un Translatable Field가 변경되지 않았는가
+        assertThat(sampleEntityInFrench.unTranslatableField).isEqualTo(defaultField);
+        assertThat(sampleEntityInFrench.unTranslatableField2).isEqualTo(defaultField);
+    }
+
+    @DisplayName("지원하는 TranslationId에 대하여 getTranslationContent가 작동하는 가 테스트")
+    @Test
+    void getTranslationContent() {
+        // given
+        Long id = 1L;
+        String defaultField = "기본값";
+        String translatableFieldName = "translatableField";
+        String translatableFieldInEnglish = "english";
+        SampleEntity sampleEntity = new SampleEntity(id, defaultField, defaultField, defaultField, defaultField);
+        String className = sampleEntity.getClass().getSimpleName();
+
+        TranslationId translationId = new TranslationId(className,  translatableFieldName, id, Locale.ENGLISH);
+
+        translationRepository.save(Translation.builder()
+                .translationId(translationId)
+                .content(translatableFieldInEnglish)
+                .build()
+        );
+
+        // when
+        String content = translationService.getTranslationContent(translationId);
+        String content2 = translationService.getTranslationContent(className, translatableFieldName, id, Locale.ENGLISH);
+        String content3 = translationService.getTranslationContent(sampleEntity, translatableFieldName, Locale.ENGLISH);
+
+        // then
+        assertThat(content).isEqualTo(translatableFieldInEnglish);
+        assertThat(content2).isEqualTo(translatableFieldInEnglish);
+        assertThat(content3).isEqualTo(translatableFieldInEnglish);
+    }
+
+    @DisplayName("지원하지 않는 TranslationId에 대하여 getTranslationContent가 에러를 던지는 가에 대한 실패 테스트")
+    @Test
+    void getTranslationContentFailed() {
+        // given
+        Long id = 1L;
+        Long wrongId = 2L;
+        String defaultField = "기본값";
+
+        SampleEntity sampleEntity = new SampleEntity(id, defaultField, defaultField, defaultField, defaultField);
+
+        String className = sampleEntity.getClass().getSimpleName();
+        String wrongClassName = "wrongClass";
+        String translatableFieldName = "translatableField";
+        String wrongTranslatableFieldName = "wrongField";
+        String translatableFieldInEnglish = "english";
+
+        TranslationId translationId = new TranslationId(className, translatableFieldName, id, Locale.ENGLISH);
+
+        translationRepository.save(Translation.builder()
+                .translationId(translationId)
+                .content(translatableFieldInEnglish)
+                .build()
+        );
+
+        // 가능한 모든 failed translation id를 저장하는 로직
+        List<TranslationId> failedTranslationIds = new ArrayList<>();
+        Stream.of(className, wrongClassName).forEach(currentClassName ->
+            Stream.of(translatableFieldName, wrongTranslatableFieldName).forEach(currentFieldName ->
+                Stream.of(id, wrongId).forEach(currentId ->
+                    Stream.of(Locale.ENGLISH, Locale.KOREAN).forEach(currentLocale -> {
+                        TranslationId currentTranslationId = new TranslationId(className, currentFieldName, id, currentLocale);
+                        if (! currentTranslationId.equals(translationId)) {
+                            failedTranslationIds.add(currentTranslationId);
+                        }
+                    })
+                )
+            )
+        );
+
+        // when & then
+        failedTranslationIds.forEach(failedTranslationId ->
+            assertThatThrownBy(() -> translationService.getTranslationContent(failedTranslationId))
+                    .isInstanceOf(TranslationNotFoundException.class)
+        );
+    }
+
+    @Test
+    void addTranslation() {
+        // TODO
+    }
+}

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/sample/SampleEntity.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/translation/sample/SampleEntity.java
@@ -1,0 +1,29 @@
+package com.startingblue.fourtooncookie.translation.sample;
+
+
+import com.startingblue.fourtooncookie.translation.annotation.TranslatableField;
+import jakarta.persistence.Id;
+
+public class SampleEntity {
+
+    @Id
+    public Long id;
+
+    @TranslatableField
+    public String translatableField;
+
+    @TranslatableField
+    public String translatableField2;
+
+    public String unTranslatableField;
+
+    public String unTranslatableField2;
+
+    public SampleEntity(Long id, String translatableField, String translatableField2, String unTranslatableField, String unTranslatableField2) {
+        this.id = id;
+        this.translatableField = translatableField;
+        this.translatableField2 = translatableField2;
+        this.unTranslatableField = unTranslatableField;
+        this.unTranslatableField2 = unTranslatableField2;
+    }
+}


### PR DESCRIPTION
# [feat] Translation(국제화 테이블) 구현
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-462
---
* 구현 내용

1. 기존의 XML을 대체하여 국제화 테이블을 제작하였습니다.

2. 모든 국제화 db 내용은 translation 테이블에서 관리되도록 하였습니다.
이때, 필드는 다음과 같이 총 5개입니다.
className(PK, String)
classId(PK, Long)
filedName(PK, String)
locale(PK, Locale)
content(String)

3. character, artwork에 해당 translation에 대한 내용을 구현해놓았습니다.

4. 사용 방법은 다음과 같습니다.
예시로 국제화가 필요한 다음과 같은 도메인이 존재한다고 하겠습니다.
SampleEntity table
id (PK, Long)
aField (String, 번역할 내용이 있음)
bField (String, 번역할 내용이 없음)
그러면 다음과 같이 @TranslatableField 어노테이션을 붙입니다.

```java
@Entity
@Getter //설명의 용이성을 위해 붙인 것이지 필수는 아닙니다.
@AllArgsConstructor //설명의 용이성을 위해 붙인 것이지 필수는 아닙니다.
class SampleEntity {
    @Id // 무조건 필요합니다. 추후 translationService에서 해당 어노테이션으로 classId를 알아냅니다.
    private Long id;

    @TranslatableField
    private String aField; // 추후에 번역이 되면 내용을 바꿔야 하는 필드

    private String bField; // 번역과 상관없이 유지되어야 하는 필드
}
```

그러면 예를 들어서 
```java
TranslationService translationService; // 빈 등록을 통해 등록되었다고 합시다.
SampleEntity sampleEntity = new SampleEntity(1L, "안녕의 기본값", "잘가");
```
와 같은 변수가 존재한다고 합시다.
그리고 이제 translation 필드에 다음과 같이 값들이 있다고 합니다. (편의상 java처럼 표현했습니다. 실제 저장되는 느낌과는 또 다를 수 있습니다.)

1번 원소
className = "SampleEntity"
classId = 1L
fieldName = "aField"
locale = "ko"
content = "안녕"

2번 원소
className = "SampleEntity"
classId = 1L
fieldName = "aField"
locale = "en"
content = "Hi"

그러면 이제 이 원소들을 활용해서 위의 코드에서 번역하면 다음과 같이 작동합니다.

```java
TranslationService translationService; // 빈 등록을 통해 등록되었다고 합시다.
SampleEntity sampleEntity = new SampleEntity(1L, "안녕의 기본값", "잘가");

SampleEntity koreanSampleEntity = translationService.translate(sampleEntity, Locale.KOREAN);
System.out.println(koreanSampleEntity.getAField()); // 안녕
System.out.println(koreanSampleEntity.getBField()); // 잘가

SampleEntity englishSampleEntity = translationService.translate(sampleEntity, Locale.ENGLISH);
System.out.println(englishSampleEntity.getAField()); // Hi
System.out.println(englishSampleEntity.getBField()); // 잘가

// 존재하지 않는 Locale로 진행하는 경우
SampleEntity noLocaleSampleEntity = translationService.translate(sampleEntity, Locale.NOTEXIST);
System.out.println(noLocaleSampleEntity.getAField()); // 안녕의 기본값 (기존에 등록된 값으로 그대로 나옵니다.)
System.out.println(noLocaleSampleEntity.getBField()); // 잘가

```

곧, translationService.translate() 함수만 작동시키면 entity가 번역되어서 나옵니다.

**이때, 기존의 객체에서 clone하는 것이 아닌 단순히 필드의 값만 바꿉니다.
따라서 JPA entity이면 그대로 필드를 바꾼다라는 것은 굉장히 위험하기에 translationService.translate에 그대로 object를 넣는 것이 아닌 clone 된 object를 넣는 것을 추천드립니다.**

그리고 @TranslatableField에 붙는 변수는 private이던 public이던 상관은 없습니다
다만, 자료형이 String이어야 합니다. (국제화인데.. 문자열을 국제화 해야 하니까요)


+ 현재 테스트를 미 진행하여 테스트 진행 후 merge하겠습니다.