### PR TITLE
[refactor] Diary, Artwork, Member, ArgumentResolve, DiaryOwnerAuthorizationInterceptor 메서드 이름 리팩토링

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkController.java
@@ -20,7 +20,7 @@ public class ArtworkController {
 
     @PostMapping
     public ResponseEntity<HttpStatus> postArtwork(@Valid @RequestBody final ArtworkSaveRequest request) {
-        artworkService.createArtwork(request);
+        artworkService.addArtwork(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .build();
@@ -29,12 +29,12 @@ public class ArtworkController {
     @GetMapping
     public ResponseEntity<ArtworkSavedResponses> getAllArtwork(Locale locale) {
         return ResponseEntity
-                .ok(ArtworkSavedResponses.of(artworkService.readAllArtworks(locale)));
+                .ok(ArtworkSavedResponses.of(artworkService.getAllArtworks(locale)));
     }
 
     @PutMapping("/{artworkId}")
     public ResponseEntity<HttpStatus> putArtwork(@PathVariable final Long artworkId, @Valid @RequestBody final ArtworkUpdateRequest request) {
-        artworkService.updateArtwork(artworkId, request);
+        artworkService.modifyArtwork(artworkId, request);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
@@ -42,7 +42,7 @@ public class ArtworkController {
 
     @DeleteMapping("/{artworkId}")
     public ResponseEntity<HttpStatus> deleteArtwork(@PathVariable final Long artworkId) {
-        artworkService.deleteArtwork(artworkId);
+        artworkService.removeArtwork(artworkId);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkController.java
@@ -18,22 +18,22 @@ public class ArtworkController {
 
     private final ArtworkService artworkService;
 
-    @GetMapping
-    public ResponseEntity<ArtworkSavedResponses> readAllArtwork(Locale locale) {
-        return ResponseEntity
-                .ok(ArtworkSavedResponses.of(artworkService.readAllArtworks(locale)));
-    }
-
     @PostMapping
-    public ResponseEntity<HttpStatus> createArtwork(@Valid @RequestBody final ArtworkSaveRequest request) {
+    public ResponseEntity<HttpStatus> postArtwork(@Valid @RequestBody final ArtworkSaveRequest request) {
         artworkService.createArtwork(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .build();
     }
 
+    @GetMapping
+    public ResponseEntity<ArtworkSavedResponses> getAllArtwork(Locale locale) {
+        return ResponseEntity
+                .ok(ArtworkSavedResponses.of(artworkService.readAllArtworks(locale)));
+    }
+
     @PutMapping("/{artworkId}")
-    public ResponseEntity<HttpStatus> updateArtwork(@PathVariable final Long artworkId, @Valid @RequestBody final ArtworkUpdateRequest request) {
+    public ResponseEntity<HttpStatus> putArtwork(@PathVariable final Long artworkId, @Valid @RequestBody final ArtworkUpdateRequest request) {
         artworkService.updateArtwork(artworkId, request);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkRepository.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkRepository.java
@@ -8,6 +8,4 @@ import java.net.URL;
 public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
     boolean existsByTitle(String title);
     boolean existsByThumbnailUrl(URL thumbnailUrl);
-
-    boolean existsByTitleAndThumbnailUrl(String title, URL thumbnailUrl);
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkRepository.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkRepository.java
@@ -8,4 +8,6 @@ import java.net.URL;
 public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
     boolean existsByTitle(String title);
     boolean existsByThumbnailUrl(URL thumbnailUrl);
+
+    boolean existsByTitleAndThumbnailUrl(String title, URL thumbnailUrl);
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/artwork/ArtworkService.java
@@ -67,7 +67,7 @@ public class ArtworkService {
 
     @Transactional(readOnly = true)
     public void validateUniqueArtwork(String title, URL thumbnailUrl) {
-        if (artworkRepository.existsByTitleAndThumbnailUrl(title, thumbnailUrl)) {
+        if (artworkRepository.existsByTitle(title) && artworkRepository.existsByThumbnailUrl(thumbnailUrl)) {
             throw new ArtworkDuplicateException("Artwork with title, thumbnail URL already exists.");
         }
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterController.java
@@ -20,31 +20,31 @@ public final class CharacterController {
     private final CharacterService characterService;
 
     @PostMapping
-    public ResponseEntity<HttpStatus> createCharacter(@Valid @RequestBody final CharacterSaveRequest request) {
-        characterService.createCharacter(request);
+    public ResponseEntity<HttpStatus> postCharacter(@Valid @RequestBody final CharacterSaveRequest request) {
+        characterService.addCharacter(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .build();
     }
 
-    @GetMapping
-    public ResponseEntity<CharacterSavedResponses> readAllCharacters(Locale locale) {
-        CharacterSavedResponses responses = CharacterSavedResponses.of(characterService.readAllCharacters(locale));
-        return ResponseEntity
-                .ok(responses);
-    }
-
     @GetMapping("/{characterId}")
-    public ResponseEntity<CharacterSavedResponse> readCharacter(@PathVariable final Long characterId, Locale locale) {
-        CharacterSavedResponse response = CharacterSavedResponse.of(characterService.readById(characterId, locale));
+    public ResponseEntity<CharacterSavedResponse> getCharacter(@PathVariable final Long characterId, Locale locale) {
+        CharacterSavedResponse response = CharacterSavedResponse.of(characterService.getById(characterId, locale));
         return ResponseEntity
                 .ok(response);
     }
 
+    @GetMapping
+    public ResponseEntity<CharacterSavedResponses> getAllCharacters(Locale locale) {
+        CharacterSavedResponses responses = CharacterSavedResponses.of(characterService.getAllCharacters(locale));
+        return ResponseEntity
+                .ok(responses);
+    }
+
     @PutMapping("/{characterId}")
-    public ResponseEntity<HttpStatus> updateCharacter(@PathVariable final Long characterId,
-                                                        @Valid @RequestBody final CharacterUpdateRequest request) {
-        characterService.updateCharacter(characterId, request);
+    public ResponseEntity<HttpStatus> putCharacter(@PathVariable final Long characterId,
+                                                   @Valid @RequestBody final CharacterUpdateRequest request) {
+        characterService.modifyCharacter(characterId, request);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
@@ -52,7 +52,7 @@ public final class CharacterController {
 
     @DeleteMapping("/{characterId}")
     public ResponseEntity<HttpStatus> deleteCharacter(@PathVariable final Long characterId) {
-        characterService.deleteCharacter(characterId);
+        characterService.removeCharacter(characterId);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -27,11 +27,11 @@ public class CharacterService {
     private final CharacterArtworkService characterArtworkService;
     private final MessageSource xmlMessageSource;
 
-    public void createCharacter(final CharacterSaveRequest request) {
+    public void addCharacter(final CharacterSaveRequest request) {
         CharacterVisionType visionType = findByCharacterVisionType(request.characterVisionType());
         Artwork artwork = characterArtworkService.readById(request.artworkId());
 
-        verifyUniqueCharacter(request.name(), artwork, request.paymentType(), visionType);
+        validateUniqueCharacter(request.name(), artwork, request.paymentType(), visionType);
 
         characterRepository.save(Character.builder()
                 .characterVisionType(visionType)
@@ -44,19 +44,32 @@ public class CharacterService {
     }
 
     @Transactional(readOnly = true)
-    public List<Character> readAllCharacters() {
+    public Character getById(Long characterId) {
+        return characterRepository.findById(characterId)
+                .orElseThrow(() -> new CharacterNotFoundException("Character with ID " + characterId + " not found"));
+    }
+
+    @Transactional(readOnly = true)
+    public Character getById(Long characterId, Locale locale) {
+        Character foundCharacter = getById(characterId);
+        return localizeCharacter(foundCharacter, locale);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<Character> getAllCharacters() {
         return characterRepository.findAll();
     }
 
     @Transactional(readOnly = true)
-    public List<Character> readAllCharacters(Locale locale) {
-        return readAllCharacters().stream()
+    public List<Character> getAllCharacters(Locale locale) {
+        return getAllCharacters().stream()
                 .map(character -> localizeCharacter(character, locale))
                 .toList();
     }
 
-    public void updateCharacter(final Long characterId, final CharacterUpdateRequest request) {
-        Character character = readById(characterId);
+    public void modifyCharacter(final Long characterId, final CharacterUpdateRequest request) {
+        Character character = getById(characterId);
         Artwork artwork = characterArtworkService.readById(request.artworkId());
 
         character.update(request.characterVisionType(),
@@ -68,21 +81,9 @@ public class CharacterService {
         characterRepository.save(character);
     }
 
-    public void deleteCharacter(final Long characterId) {
-        Character foundCharacter = readById(characterId);
+    public void removeCharacter(final Long characterId) {
+        Character foundCharacter = getById(characterId);
         characterRepository.delete(foundCharacter);
-    }
-
-    @Transactional(readOnly = true)
-    public Character readById(Long characterId) {
-        return characterRepository.findById(characterId)
-                .orElseThrow(() -> new CharacterNotFoundException("Character with ID " + characterId + " not found"));
-    }
-
-    @Transactional(readOnly = true)
-    public Character readById(Long characterId, Locale locale) {
-        Character foundCharacter = readById(characterId);
-        return localizeCharacter(foundCharacter, locale);
     }
 
     private Character localizeCharacter(Character character, Locale locale) {
@@ -112,14 +113,14 @@ public class CharacterService {
         return CharacterVisionType.valueOf(characterVisionType.name());
     }
 
-    private void verifyUniqueCharacter(String name, Artwork artwork, PaymentType paymentType, CharacterVisionType visionType) {
+    private void validateUniqueCharacter(String name, Artwork artwork, PaymentType paymentType, CharacterVisionType visionType) {
         boolean isDuplicate = characterRepository.existsByName(name) &&
                 characterRepository.existsByArtwork(artwork) &&
                 characterRepository.existsByPaymentType(paymentType) &&
                 characterRepository.existsByCharacterVisionType(visionType);
 
         if (isDuplicate) {
-            throw new CharacterDuplicateException("중복된 캐릭터입니다. 동일한 이름, 작품, 결제 유형, 캐릭터 비전 유형을 가진 캐릭터가 이미 존재합니다.");
+            throw new CharacterDuplicateException("Duplicate character. A character with the same name, work, payment type, and character vision type already exists.");
         }
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -114,12 +114,10 @@ public class CharacterService {
     }
 
     private void validateUniqueCharacter(String name, Artwork artwork, PaymentType paymentType, CharacterVisionType visionType) {
-        boolean isDuplicate = characterRepository.existsByName(name) &&
+        if (characterRepository.existsByName(name) &&
                 characterRepository.existsByArtwork(artwork) &&
                 characterRepository.existsByPaymentType(paymentType) &&
-                characterRepository.existsByCharacterVisionType(visionType);
-
-        if (isDuplicate) {
+                characterRepository.existsByCharacterVisionType(visionType)) {
             throw new CharacterDuplicateException("Duplicate character. A character with the same name, work, payment type, and character vision type already exists.");
         }
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -11,13 +11,11 @@ import com.startingblue.fourtooncookie.character.exception.CharacterNotFoundExce
 import com.startingblue.fourtooncookie.character.service.CharacterArtworkService;
 import com.startingblue.fourtooncookie.character.service.CharacterTranslationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 @RequiredArgsConstructor
 @Transactional
@@ -29,7 +27,7 @@ public class CharacterService {
     private final CharacterTranslationService characterTranslationService;
 
     public void addCharacter(final CharacterSaveRequest request) {
-        CharacterVisionType visionType = getByCharacterVisionType(request.characterVisionType());
+        CharacterVisionType visionType = getCharacterVisionType(request.characterVisionType());
         Artwork artwork = characterArtworkService.getById(request.artworkId());
 
         validateUniqueCharacter(request.name(), artwork, request.paymentType(), visionType);
@@ -87,7 +85,7 @@ public class CharacterService {
         characterRepository.delete(foundCharacter);
     }
 
-    private CharacterVisionType getByCharacterVisionType(CharacterVisionType characterVisionType) {
+    private CharacterVisionType getCharacterVisionType(CharacterVisionType characterVisionType) {
         return CharacterVisionType.valueOf(characterVisionType.name());
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/CharacterService.java
@@ -29,7 +29,7 @@ public class CharacterService {
 
     public void addCharacter(final CharacterSaveRequest request) {
         CharacterVisionType visionType = findByCharacterVisionType(request.characterVisionType());
-        Artwork artwork = characterArtworkService.readById(request.artworkId());
+        Artwork artwork = characterArtworkService.getById(request.artworkId());
 
         validateUniqueCharacter(request.name(), artwork, request.paymentType(), visionType);
 
@@ -70,7 +70,7 @@ public class CharacterService {
 
     public void modifyCharacter(final Long characterId, final CharacterUpdateRequest request) {
         Character character = getById(characterId);
-        Artwork artwork = characterArtworkService.readById(request.artworkId());
+        Artwork artwork = characterArtworkService.getById(request.artworkId());
 
         character.update(request.characterVisionType(),
                 request.paymentType(),

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
@@ -14,7 +14,7 @@ public class CharacterArtworkService {
     private final ArtworkService artworkService;
 
     public Artwork readById(Long artworkId) {
-        return artworkService.readById(artworkId);
+        return artworkService.getById(artworkId);
     }
 
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/character/service/CharacterArtworkService.java
@@ -13,7 +13,7 @@ public class CharacterArtworkService {
 
     private final ArtworkService artworkService;
 
-    public Artwork readById(Long artworkId) {
+    public Artwork getById(Long artworkId) {
         return artworkService.getById(artworkId);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -26,14 +26,14 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping
-    public ResponseEntity<DiaryCreatedResponse> createDiary(UUID memberId,
-                                                            @RequestBody final DiarySaveRequest request) {
+    public ResponseEntity<DiaryCreatedResponse> postDiary(UUID memberId,
+                                                          @RequestBody final DiarySaveRequest request) {
         DiaryCreatedResponse createdDiaryId = new DiaryCreatedResponse(diaryService.addDiary(request, memberId));
         return ResponseEntity.ok(createdDiaryId);
     }
 
     @GetMapping("/timeline")
-    public ResponseEntity<DiarySavedResponses> readDiariesByMember (
+    public ResponseEntity<DiarySavedResponses> getDiaries(
             UUID memberId,
             @RequestParam(defaultValue = "0") @Min(0) @Max(200) final int pageNumber,
             @RequestParam(defaultValue = "10") @Min(1) @Max(10) final int pageSize) {
@@ -47,23 +47,33 @@ public class DiaryController {
     }
 
     @GetMapping("/{diaryId}")
-    public ResponseEntity<DiarySavedResponse> readDiaryById (
+    public ResponseEntity<DiarySavedResponse> getDiary(
             @PathVariable final Long diaryId) {
         DiarySavedResponse response = DiarySavedResponse.of(diaryService.getById(diaryId));
         return ok(response);
     }
 
-    @PutMapping("/{diaryId}")
-    public ResponseEntity<HttpStatus> updateDiary(@PathVariable final Long diaryId,
-                                            @RequestBody final DiaryUpdateRequest request) {
-        diaryService.modifyDiary(diaryId, request);
-        return ok().build();
+    @GetMapping("/{diaryId}/image/full")
+    public ResponseEntity<byte[]> getDiaryFullImage(@PathVariable final Long diaryId) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_PNG);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(diaryService.getDiaryFullImage(diaryId));
     }
 
     @PatchMapping("/{diaryId}/favorite")
-    public ResponseEntity<HttpStatus> updateDiaryFavorite(@PathVariable final Long diaryId,
-                                                    @RequestBody final DiaryFavoriteRequest diaryFavoriteRequest) {
+    public ResponseEntity<HttpStatus> patchDiaryFavorite(@PathVariable final Long diaryId,
+                                                         @RequestBody final DiaryFavoriteRequest diaryFavoriteRequest) {
         diaryService.modifyDiaryFavorite(diaryId, diaryFavoriteRequest.isFavorite());
+        return ok().build();
+    }
+
+    @PutMapping("/{diaryId}")
+    public ResponseEntity<HttpStatus> putDiary(@PathVariable final Long diaryId,
+                                               @RequestBody final DiaryUpdateRequest request) {
+        diaryService.modifyDiary(diaryId, request);
         return ok().build();
     }
 
@@ -71,16 +81,6 @@ public class DiaryController {
     public ResponseEntity<HttpStatus> deleteDiary(@PathVariable final Long diaryId) {
         diaryService.removeDiaryById(diaryId);
         return noContent().build();
-    }
-
-    @GetMapping("/{diaryId}/image/full")
-    public ResponseEntity<byte[]> readDiaryByIdDownload(@PathVariable final Long diaryId) throws IOException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.IMAGE_PNG);
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(diaryService.getDiaryFullImage(diaryId));
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryController.java
@@ -28,7 +28,7 @@ public class DiaryController {
     @PostMapping
     public ResponseEntity<DiaryCreatedResponse> createDiary(UUID memberId,
                                                             @RequestBody final DiarySaveRequest request) {
-        DiaryCreatedResponse createdDiaryId = new DiaryCreatedResponse(diaryService.createDiary(request, memberId));
+        DiaryCreatedResponse createdDiaryId = new DiaryCreatedResponse(diaryService.addDiary(request, memberId));
         return ResponseEntity.ok(createdDiaryId);
     }
 
@@ -38,7 +38,7 @@ public class DiaryController {
             @RequestParam(defaultValue = "0") @Min(0) @Max(200) final int pageNumber,
             @RequestParam(defaultValue = "10") @Min(1) @Max(10) final int pageSize) {
 
-        DiarySavedResponses responses = DiarySavedResponses.of(diaryService.readDiariesByMemberId(memberId, pageNumber, pageSize));
+        DiarySavedResponses responses = DiarySavedResponses.of(diaryService.getDiariesByMemberId(memberId, pageNumber, pageSize));
 
         if (responses.diarySavedResponses().isEmpty()) {
             return noContent().build();
@@ -49,27 +49,27 @@ public class DiaryController {
     @GetMapping("/{diaryId}")
     public ResponseEntity<DiarySavedResponse> readDiaryById (
             @PathVariable final Long diaryId) {
-        DiarySavedResponse response = DiarySavedResponse.of(diaryService.readDiaryById(diaryId));
+        DiarySavedResponse response = DiarySavedResponse.of(diaryService.getById(diaryId));
         return ok(response);
     }
 
     @PutMapping("/{diaryId}")
     public ResponseEntity<HttpStatus> updateDiary(@PathVariable final Long diaryId,
                                             @RequestBody final DiaryUpdateRequest request) {
-        diaryService.updateDiary(diaryId, request);
+        diaryService.modifyDiary(diaryId, request);
         return ok().build();
     }
 
     @PatchMapping("/{diaryId}/favorite")
     public ResponseEntity<HttpStatus> updateDiaryFavorite(@PathVariable final Long diaryId,
                                                     @RequestBody final DiaryFavoriteRequest diaryFavoriteRequest) {
-        diaryService.updateDiaryFavorite(diaryId, diaryFavoriteRequest.isFavorite());
+        diaryService.modifyDiaryFavorite(diaryId, diaryFavoriteRequest.isFavorite());
         return ok().build();
     }
 
     @DeleteMapping("/{diaryId}")
     public ResponseEntity<HttpStatus> deleteDiary(@PathVariable final Long diaryId) {
-        diaryService.deleteDiaryById(diaryId);
+        diaryService.removeDiaryById(diaryId);
         return noContent().build();
     }
 
@@ -80,7 +80,7 @@ public class DiaryController {
 
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(diaryService.readDiaryFullImage(diaryId));
+                .body(diaryService.getDiaryFullImage(diaryId));
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
@@ -125,7 +125,7 @@ public class DiaryService {
 
     public void removeDiaryById(Long diaryId) {
         Diary foundDiary = getById(diaryId);
-        diaryS3Service.deleteImagesByDiaryId(diaryId);
+        diaryS3Service.removeImagesByDiaryId(diaryId);
         diaryRepository.delete(foundDiary);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
@@ -44,7 +44,7 @@ public class DiaryService {
     private final DiaryLambdaService diaryImageGenerationLambdaInvoker;
 
     public Long addDiary(final DiarySaveRequest request, final UUID memberId) {
-        Character character = diaryCharacterService.readById(request.characterId());
+        Character character = diaryCharacterService.getById(request.characterId());
         
         Diary diary = buildDiary(request, memberId, character);
         diaryRepository.save(diary);
@@ -112,7 +112,7 @@ public class DiaryService {
 
     public void modifyDiary(Long diaryId, DiaryUpdateRequest request) {
         Diary existedDiary = getById(diaryId);
-        Character character = diaryCharacterService.readById(request.characterId());
+        Character character = diaryCharacterService.getById(request.characterId());
         existedDiary.update(request.content(), character);
         diaryImageGenerationLambdaInvoker.invokeDiaryImageGenerationLambda(existedDiary, character);
         diaryPaintingImageCloudFrontService.invalidateCache(diaryId);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.net.URL;
-import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -44,7 +43,7 @@ public class DiaryService {
     private final DiaryPaintingImageCloudFrontService diaryPaintingImageCloudFrontService;
     private final DiaryLambdaService diaryImageGenerationLambdaInvoker;
 
-    public Long createDiary(final DiarySaveRequest request, final UUID memberId) {
+    public Long addDiary(final DiarySaveRequest request, final UUID memberId) {
         Character character = diaryCharacterService.readById(request.characterId());
         
         Diary diary = buildDiary(request, memberId, character);
@@ -67,17 +66,17 @@ public class DiaryService {
     }
 
     @Transactional(readOnly = true)
-    public Diary readDiaryById(final Long diaryId) {
-        Optional<Diary> foundDiary = diaryRepository.findById(diaryId);
-        if (foundDiary.get().isCompleted()) {
-            List<URL> signedUrls = generateSignedUrls(foundDiary.get().getId());
-            foundDiary.get().updatePaintingImageUrls(signedUrls);
+    public Diary getById(final Long diaryId) {
+        Diary foundDiary = diaryRepository.findById(diaryId).orElseThrow(DiaryNotFoundException::new);
+        if (foundDiary.isCompleted()) {
+            List<URL> signedUrls = generateSignedUrls(foundDiary.getId());
+            foundDiary.updatePaintingImageUrls(signedUrls);
         }
-        return foundDiary.get();
+        return foundDiary;
     }
 
     @Transactional(readOnly = true)
-    public List<Diary> readDiariesByMemberId(final UUID memberId, final int pageNumber, final int pageSize) {
+    public List<Diary> getDiariesByMemberId(final UUID memberId, final int pageNumber, final int pageSize) {
         Page<Diary> diaries = diaryRepository.findAllByMemberIdOrderByDiaryDateDesc(
                 memberId,
                 PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "diaryDate"))
@@ -93,7 +92,7 @@ public class DiaryService {
     }
 
     @Transactional(readOnly = true)
-    public byte[] readDiaryFullImage(final Long diaryId) throws IOException {
+    public byte[] getDiaryFullImage(final Long diaryId) throws IOException {
         return diaryS3Service.getFullImageByDiaryId(diaryId);
     }
 
@@ -111,40 +110,32 @@ public class DiaryService {
                 .toList();
     }
 
-    public void updateDiaryFavorite(Long diaryId, boolean isFavorite) {
-        Diary foundDiary = readById(diaryId);
-        foundDiary.updateFavorite(isFavorite);
-    }
-
-    public void updateDiary(Long diaryId, DiaryUpdateRequest request) {
-        Diary existedDiary = readById(diaryId);
+    public void modifyDiary(Long diaryId, DiaryUpdateRequest request) {
+        Diary existedDiary = getById(diaryId);
         Character character = diaryCharacterService.readById(request.characterId());
         existedDiary.update(request.content(), character);
         diaryImageGenerationLambdaInvoker.invokeDiaryImageGenerationLambda(existedDiary, character);
         diaryPaintingImageCloudFrontService.invalidateCache(diaryId);
     }
 
-    public void deleteDiaryById(Long diaryId) {
-        Diary foundDiary = readById(diaryId);
+    public void modifyDiaryFavorite(Long diaryId, boolean isFavorite) {
+        Diary foundDiary = getById(diaryId);
+        foundDiary.updateFavorite(isFavorite);
+    }
+
+    public void removeDiaryById(Long diaryId) {
+        Diary foundDiary = getById(diaryId);
         diaryS3Service.deleteImagesByDiaryId(diaryId);
         diaryRepository.delete(foundDiary);
     }
 
     @Transactional(readOnly = true)
-    public Diary readById(final Long id) {
-        return diaryRepository.findById(id)
-                .orElseThrow(DiaryNotFoundException::new);
-    }
-
-    @Transactional(readOnly = true)
-    public boolean verifyDiaryOwner(UUID memberId, Long diaryId) {
-        Diary foundDiary = readById(diaryId);
-        return foundDiary.isOwner(memberId);
+    public boolean isDiaryOwner(UUID memberId, Long diaryId) {
+        return getById(diaryId).isOwner(memberId);
     }
 
     @Transactional
     public boolean existsById(Long diaryId) {
-        if (diaryId == null) return false;
         return diaryRepository.existsById(diaryId);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/DiaryService.java
@@ -135,7 +135,7 @@ public class DiaryService {
     }
 
     @Transactional
-    public boolean existsById(Long diaryId) {
+    public boolean isExistsById(Long diaryId) {
         return diaryRepository.existsById(diaryId);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/listener/DiarySQSMessageListener.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/listener/DiarySQSMessageListener.java
@@ -30,7 +30,7 @@ public class DiarySQSMessageListener {
             try {
                 DiaryImageResponseMessage response = parseMessage(message);
                 log.info("received message: {}", response);
-                if (!diaryService.existsById(response.diaryId())) {
+                if (!diaryService.isExistsById(response.diaryId())) {
                     log.info("Diary ID {} does not exist. Message will be ignored.", response.diaryId());
                     // 다이어리 ID가 없을 경우 처리를 하지 않음 (메시지 삭제)
                     return;

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/listener/DiarySQSMessageListener.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/listener/DiarySQSMessageListener.java
@@ -36,7 +36,7 @@ public class DiarySQSMessageListener {
                     return;
                 }
 
-                DiaryStatus currentDiaryStatus = diaryService.readById(response.diaryId()).getStatus();
+                DiaryStatus currentDiaryStatus = diaryService.getById(response.diaryId()).getStatus();
 
                 diaryService.processImageGenerationResponse(response);
 
@@ -44,7 +44,7 @@ public class DiarySQSMessageListener {
                     return;
                 }
 
-                Diary diary = diaryService.readById(response.diaryId());
+                Diary diary = diaryService.getById(response.diaryId());
                 if (!DiaryStatus.IN_PROGRESS.equals(diary.getStatus())) {
                     notificationService.sendNotificationToMember(diary.getMemberId(), diary);
                 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryCharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryCharacterService.java
@@ -12,7 +12,7 @@ public class DiaryCharacterService {
     private final CharacterService characterService;
 
     public Character getById(Long characterId) {
-        return characterService.readById(characterId);
+        return characterService.getById(characterId);
     }
 
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryCharacterService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryCharacterService.java
@@ -11,7 +11,7 @@ public class DiaryCharacterService {
 
     private final CharacterService characterService;
 
-    public Character readById(Long characterId) {
+    public Character getById(Long characterId) {
         return characterService.readById(characterId);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryS3Service.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/diary/service/DiaryS3Service.java
@@ -44,7 +44,7 @@ public class DiaryS3Service {
         return String.format("%s/%s.%s", diaryId, gridPosition, imageFormat);
     }
 
-    public void deleteImagesByDiaryId(Long diaryId) {
+    public void removeImagesByDiaryId(Long diaryId) {
         s3Service.deleteObjectsInFolder(bucketName, String.valueOf(diaryId));
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
@@ -17,19 +17,19 @@ public final class MemberController {
 
     @PostMapping("/member")
     public ResponseEntity<HttpStatus> postMember(UUID memberId, @RequestBody MemberSaveRequest memberSaveRequest) {
-        memberService.add(memberId, memberSaveRequest);
+        memberService.addMember(memberId, memberSaveRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/member")
     public ResponseEntity<MemberSavedResponse> getMember(UUID memberId) {
-        MemberSavedResponse response = MemberSavedResponse.of(memberService.readById(memberId));
+        MemberSavedResponse response = MemberSavedResponse.of(memberService.getById(memberId));
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/member")
-    public ResponseEntity<HttpStatus> hardDeleteMember(UUID memberId) {
-        memberService.hardDeleteById(memberId);
+    public ResponseEntity<HttpStatus> deleteMember(UUID memberId) {
+        memberService.removeById(memberId);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
@@ -15,16 +15,16 @@ public final class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/member")
-    public ResponseEntity<MemberSavedResponse> readMember(UUID memberId) {
-        MemberSavedResponse response = MemberSavedResponse.of(memberService.readById(memberId));
-        return ResponseEntity.ok(response);
+    @PostMapping("/member")
+    public ResponseEntity<HttpStatus> postMember(UUID memberId, @RequestBody MemberSaveRequest memberSaveRequest) {
+        memberService.add(memberId, memberSaveRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("/member")
-    public ResponseEntity<HttpStatus> saveMember(UUID memberId, @RequestBody MemberSaveRequest memberSaveRequest) {
-        memberService.save(memberId, memberSaveRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+    @GetMapping("/member")
+    public ResponseEntity<MemberSavedResponse> getMember(UUID memberId) {
+        MemberSavedResponse response = MemberSavedResponse.of(memberService.readById(memberId));
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/member")

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberService.java
@@ -39,7 +39,7 @@ public class MemberService {
     }
 
     public void removeById(UUID memberId) {
-        memberDiaryService.deleteDiariesByMemberId(memberId);
+        memberDiaryService.removeDiariesByMemberId(memberId);
         memberRepository.deleteById(memberId);
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberService.java
@@ -20,10 +20,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberDiaryService memberDiaryService;
 
-    public void save(UUID memberId, MemberSaveRequest memberSaveRequest) {
-        if (verifyMemberExists(memberId)) {
-            throw new MemberDuplicateException("Member with id " + memberId + " already exists");
-        }
+    public void addMember(UUID memberId, MemberSaveRequest memberSaveRequest) {
+        validateMemberExists(memberId);
 
         Member member = Member.builder()
                 .id(memberId)
@@ -32,29 +30,31 @@ public class MemberService {
                 .gender(memberSaveRequest.gender())
                 .role(Role.MEMBER)
                 .build();
+
         memberRepository.save(member);
     }
 
-    public Member readById(UUID memberId) {
+    public Member getById(UUID memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
     }
 
-    public void hardDeleteById(UUID memberId) {
+    public void removeById(UUID memberId) {
         memberDiaryService.deleteDiariesByMemberId(memberId);
         memberRepository.deleteById(memberId);
     }
 
-    public boolean verifyMemberExists(UUID memberId) {
-        return memberRepository.existsById(memberId);
+    public void validateMemberExists(UUID memberId) {
+        if (memberRepository.existsById(memberId)) {
+            throw new MemberDuplicateException("Member with id " + memberId + " already exists");
+        }
     }
 
-    public boolean verifyMemberSignUp(UUID memberId) {
-        Member member = readById(memberId);
+    public boolean isMemberSignUp(UUID memberId) {
+        Member member = getById(memberId);
         return member != null && member.getName() != null && !member.getName().isEmpty();
     }
 
-    public boolean verifyMemberAdmin(UUID memberId) {
-        Member member = readById(memberId);
-        return member.isAdmin();
+    public boolean isMemberAdmin(UUID memberId) {
+        return getById(memberId).isAdmin();
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
@@ -17,7 +17,7 @@ public class MemberDiaryService {
     private final DiaryRepository diaryRepository;
     private final DiaryService diaryService;
 
-    public void deleteDiariesByMemberId(UUID memberId) {
+    public void removeDiariesByMemberId(UUID memberId) {
         List<Long> diaryIds = diaryRepository.findDiaryIdsByMemberId(memberId);
         for (Long diaryId : diaryIds) {
             diaryService.removeDiaryById(diaryId);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberDiaryService.java
@@ -2,7 +2,6 @@ package com.startingblue.fourtooncookie.member.service;
 
 import com.startingblue.fourtooncookie.diary.DiaryRepository;
 import com.startingblue.fourtooncookie.diary.DiaryService;
-import com.startingblue.fourtooncookie.diary.service.DiaryS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +20,7 @@ public class MemberDiaryService {
     public void deleteDiariesByMemberId(UUID memberId) {
         List<Long> diaryIds = diaryRepository.findDiaryIdsByMemberId(memberId);
         for (Long diaryId : diaryIds) {
-            diaryService.deleteDiaryById(diaryId);
+            diaryService.removeDiaryById(diaryId);
         }
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/ArgumentResolver.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/ArgumentResolver.java
@@ -26,7 +26,7 @@ public class ArgumentResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         HttpServletRequest request = getRequest(webRequest);
-        String memberIdString = getMemberIdString(request);
+        String memberIdString = getMemberId(request);
         return parseMemberId(memberIdString);
     }
 
@@ -38,7 +38,7 @@ public class ArgumentResolver implements HandlerMethodArgumentResolver {
         return request;
     }
 
-    private String getMemberIdString(HttpServletRequest request) {
+    private String getMemberId(HttpServletRequest request) {
         String memberIdString = String.valueOf(request.getAttribute("memberId"));
         if (memberIdString == null || memberIdString.isEmpty()) {
             throw new AuthenticationException("Member ID is missing");

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
@@ -88,6 +88,6 @@ public class AuthenticationFilter extends HttpFilter {
     }
 
     private boolean isExistsMember(UUID memberId) {
-        return memberService.verifyMemberExists(memberId);
+        return memberService.isMemberSignUp(memberId);
     }
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
@@ -32,7 +32,7 @@ public class AuthenticationFilter extends HttpFilter {
         String requestURI = request.getRequestURI();
         String method = request.getMethod();
 
-        if (shouldBypassAuthentication(requestURI, method)) {
+        if (isPassAuthentication(requestURI, method)) {
             chain.doFilter(request, response);
             return;
         }
@@ -56,7 +56,7 @@ public class AuthenticationFilter extends HttpFilter {
         }
     }
 
-    private boolean shouldBypassAuthentication(String requestURI, String method) {
+    private boolean isPassAuthentication(String requestURI, String method) {
         return requestURI.startsWith("/h2-console") || requestURI.startsWith("/health") ||
                 (method.equalsIgnoreCase("GET") && (requestURI.startsWith("/character") || requestURI.startsWith("/artwork")));
     }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/filter/AuthenticationFilter.java
@@ -38,7 +38,7 @@ public class AuthenticationFilter extends HttpFilter {
         }
 
         try {
-            UUID memberId = extractUUIDFromToken(request);
+            UUID memberId = getUUIDByExtractingToken(request);
             log.info("Login attempt for memberId: {}", memberId);
 
             if (isSignupRequest(requestURI, method)) {
@@ -61,7 +61,7 @@ public class AuthenticationFilter extends HttpFilter {
                 (method.equalsIgnoreCase("GET") && (requestURI.startsWith("/character") || requestURI.startsWith("/artwork")));
     }
 
-    private UUID extractUUIDFromToken(HttpServletRequest request) {
+    private UUID getUUIDByExtractingToken(HttpServletRequest request) {
         String token = jwtExtractor.resolveToken(request);
         Claims claims = jwtExtractor.parseToken(token);
         return UUID.fromString(claims.getSubject());

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
@@ -34,7 +34,13 @@ public class DiaryOwnerAuthorizationInterceptor implements HandlerInterceptor {
         validateExistsId(diaryId, response);
 
         try {
-            return handleAuthorization(UUID.fromString(memberId), Long.parseLong(diaryId), response);
+            boolean isAuthorized = isAuthorized(UUID.fromString(memberId), Long.parseLong(diaryId));
+
+            if (! isAuthorized) {
+                response.setStatus(SC_FORBIDDEN);
+            }
+
+            return isAuthorized;
         } catch (IllegalArgumentException e) {
             log.warn("Invalid UUID format for memberId: {}", memberId);
             response.setStatus(SC_FORBIDDEN);
@@ -47,17 +53,6 @@ public class DiaryOwnerAuthorizationInterceptor implements HandlerInterceptor {
             log.warn("Missing or empty path variable '{}': {}", PATH_VARIABLE_MEMBER_KEY, id);
             response.setStatus(SC_FORBIDDEN);
         }
-    }
-
-    private boolean handleAuthorization(UUID memberId, long diaryId, HttpServletResponse response) {
-        if (isAuthorized(memberId, diaryId)) {
-            log.info("Member with id {} is authorized", memberId);
-            return true;
-        }
-
-        log.warn("Member with id {} is not authorized for diary {}", memberId, diaryId);
-        response.setStatus(SC_FORBIDDEN);
-        return false;
     }
 
     private boolean isAuthorized(UUID memberId, long diaryId) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
@@ -76,7 +76,7 @@ public class DiaryOwnerAuthorizationInterceptor implements HandlerInterceptor {
     }
 
     private boolean isAuthorized(UUID memberId, long diaryId) {
-        return diaryService.verifyDiaryOwner(memberId, diaryId);
+        return diaryService.isDiaryOwner(memberId, diaryId);
     }
 
     private String extractPathVariable(String requestURI) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/DiaryOwnerAuthorizationInterceptor.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.UUID;
@@ -26,43 +27,26 @@ public class DiaryOwnerAuthorizationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        String memberIdStr = String.valueOf(request.getAttribute(PATH_VARIABLE_MEMBER_KEY));
-        if (!isValidMemberId(memberIdStr, response)) {
-            return false;
-        }
-
-        String diaryIdStr = extractPathVariable(request.getRequestURI());
-        if (!isValidDiaryId(diaryIdStr, response)) {
-            return false;
-        }
+        String memberId = String.valueOf(request.getAttribute(PATH_VARIABLE_MEMBER_KEY));
+        validateExistsId(memberId, response);
+        
+        String diaryId = extractPathVariable(request.getRequestURI());
+        validateExistsId(diaryId, response);
 
         try {
-            UUID memberId = UUID.fromString(memberIdStr);
-            long diaryId = Long.parseLong(diaryIdStr);
-            return handleAuthorization(memberId, diaryId, response);
+            return handleAuthorization(UUID.fromString(memberId), Long.parseLong(diaryId), response);
         } catch (IllegalArgumentException e) {
-            log.warn("Invalid UUID format for memberId: {}", memberIdStr);
+            log.warn("Invalid UUID format for memberId: {}", memberId);
             response.setStatus(SC_FORBIDDEN);
             return false;
         }
     }
 
-    private boolean isValidMemberId(String memberIdStr, HttpServletResponse response) {
-        if (memberIdStr == null || memberIdStr.isEmpty()) {
-            log.warn("Missing or empty path variable '{}': {}", PATH_VARIABLE_MEMBER_KEY, memberIdStr);
+    private void validateExistsId(String id, HttpServletResponse response) {
+        if (!StringUtils.hasText(id)) {
+            log.warn("Missing or empty path variable '{}': {}", PATH_VARIABLE_MEMBER_KEY, id);
             response.setStatus(SC_FORBIDDEN);
-            return false;
         }
-        return true;
-    }
-
-    private boolean isValidDiaryId(String diaryIdStr, HttpServletResponse response) {
-        if (diaryIdStr == null || diaryIdStr.isEmpty()) {
-            log.warn("Missing or empty path variable '{}': {}", PATH_VARIABLE_DIARY_KEY, diaryIdStr);
-            response.setStatus(SC_FORBIDDEN);
-            return false;
-        }
-        return true;
     }
 
     private boolean handleAuthorization(UUID memberId, long diaryId, HttpServletResponse response) {
@@ -70,6 +54,7 @@ public class DiaryOwnerAuthorizationInterceptor implements HandlerInterceptor {
             log.info("Member with id {} is authorized", memberId);
             return true;
         }
+
         log.warn("Member with id {} is not authorized for diary {}", memberId, diaryId);
         response.setStatus(SC_FORBIDDEN);
         return false;

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/MemberAdminAuthorizationInterceptor.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/MemberAdminAuthorizationInterceptor.java
@@ -30,7 +30,7 @@ public class MemberAdminAuthorizationInterceptor extends MemberAuthorizationInte
 
     @Override
     public boolean isAuthorized(UUID memberId) {
-        boolean isAuthorized = memberService.verifyMemberAdmin(memberId);
+        boolean isAuthorized = memberService.isMemberAdmin(memberId);
 
         if (isAuthorized) {
             log.info("Authorization success: Member with ID [{}] has admin privileges.", memberId);

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/MemberSignedUpAuthorizationInterceptor.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/web/interceptor/MemberSignedUpAuthorizationInterceptor.java
@@ -16,7 +16,7 @@ public class MemberSignedUpAuthorizationInterceptor extends MemberAuthorizationI
 
     @Override
     public boolean isAuthorized(UUID memberId) {
-        boolean isAuthorized = memberService.verifyMemberSignUp(memberId);
+        boolean isAuthorized = memberService.isMemberSignUp(memberId);
 
         if (isAuthorized) {
             log.info("Authorization success: Member with ID [{}] is already signed up.", memberId);

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
@@ -49,8 +49,8 @@ class ArtworkServiceTest {
         ArtworkSaveRequest request = new ArtworkSaveRequest("New Artwork", new URL("http://example.com/new_image.jpg"));
 
         // 중복 확인을 위한 Mock
-        when(artworkRepository.existsByTitle(anyString())).thenReturn(false);
-        when(artworkRepository.existsByThumbnailUrl(any(URL.class))).thenReturn(false);
+        when(artworkRepository.existsByTitle(anyString())).thenReturn(true);
+        when(artworkRepository.existsByThumbnailUrl(any(URL.class))).thenReturn(true);
 
         // When
         artworkService.addArtwork(request);
@@ -66,7 +66,8 @@ class ArtworkServiceTest {
         ArtworkSaveRequest request = new ArtworkSaveRequest("Duplicate Artwork", new URL("http://example.com/image.jpg"));
 
         // 중복된 제목 존재
-        when(artworkRepository.existsByTitleAndThumbnailUrl(anyString(), any())).thenReturn(true);
+        when(artworkRepository.existsByTitle(anyString())).thenReturn(false);
+        when(artworkRepository.existsByThumbnailUrl(any())).thenReturn(false);
 
         // When & Then
         assertThatThrownBy(() -> artworkService.addArtwork(request))

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
@@ -49,8 +49,8 @@ class ArtworkServiceTest {
         ArtworkSaveRequest request = new ArtworkSaveRequest("New Artwork", new URL("http://example.com/new_image.jpg"));
 
         // 중복 확인을 위한 Mock
-        when(artworkRepository.existsByTitle(anyString())).thenReturn(true);
-        when(artworkRepository.existsByThumbnailUrl(any(URL.class))).thenReturn(true);
+        when(artworkRepository.existsByTitle(anyString())).thenReturn(false);
+        when(artworkRepository.existsByThumbnailUrl(any(URL.class))).thenReturn(false);
 
         // When
         artworkService.addArtwork(request);
@@ -66,8 +66,8 @@ class ArtworkServiceTest {
         ArtworkSaveRequest request = new ArtworkSaveRequest("Duplicate Artwork", new URL("http://example.com/image.jpg"));
 
         // 중복된 제목 존재
-        when(artworkRepository.existsByTitle(anyString())).thenReturn(false);
-        when(artworkRepository.existsByThumbnailUrl(any())).thenReturn(false);
+        when(artworkRepository.existsByTitle(anyString())).thenReturn(true);
+        when(artworkRepository.existsByThumbnailUrl(any())).thenReturn(true);
 
         // When & Then
         assertThatThrownBy(() -> artworkService.addArtwork(request))

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/artwork/service/ArtworkServiceTest.java
@@ -44,7 +44,7 @@ class ArtworkServiceTest {
 
     @Test
     @DisplayName("새로운 Artwork를 성공적으로 저장한다")
-    void testCreateArtworkSuccess() throws MalformedURLException {
+    void testAddArtworkSuccess() throws MalformedURLException {
         // Given
         ArtworkSaveRequest request = new ArtworkSaveRequest("New Artwork", new URL("http://example.com/new_image.jpg"));
 
@@ -53,7 +53,7 @@ class ArtworkServiceTest {
         when(artworkRepository.existsByThumbnailUrl(any(URL.class))).thenReturn(false);
 
         // When
-        artworkService.createArtwork(request);
+        artworkService.addArtwork(request);
 
         // Then
         verify(artworkRepository, times(1)).save(any(Artwork.class));
@@ -61,22 +61,22 @@ class ArtworkServiceTest {
 
     @Test
     @DisplayName("중복된 제목으로 Artwork 저장 시도 시 예외 발생")
-    void testCreateArtworkWithDuplicateTitle() throws MalformedURLException {
+    void testAddArtworkWithDuplicateTitle() throws MalformedURLException {
         // Given
         ArtworkSaveRequest request = new ArtworkSaveRequest("Duplicate Artwork", new URL("http://example.com/image.jpg"));
 
         // 중복된 제목 존재
-        when(artworkRepository.existsByTitle(anyString())).thenReturn(true);
+        when(artworkRepository.existsByTitleAndThumbnailUrl(anyString(), any())).thenReturn(true);
 
         // When & Then
-        assertThatThrownBy(() -> artworkService.createArtwork(request))
+        assertThatThrownBy(() -> artworkService.addArtwork(request))
                 .isInstanceOf(ArtworkDuplicateException.class)
-                .hasMessage("Artwork with title 'Duplicate Artwork' already exists.");
+                .hasMessage("Artwork with title, thumbnail URL already exists.");
     }
 
     @Test
     @DisplayName("존재하는 모든 Artwork를 성공적으로 가져온다")
-    void testReadAllArtworks() throws MalformedURLException {
+    void testGetAllArtworks() throws MalformedURLException {
         // Given
         List<Artwork> artworks = Arrays.asList(
                 new Artwork(1L, "Artwork 1", new URL("http://example.com/image1.jpg")),
@@ -86,7 +86,7 @@ class ArtworkServiceTest {
         when(artworkRepository.findAll()).thenReturn(artworks);
 
         // When
-        List<Artwork> result = artworkService.readAllArtworks();
+        List<Artwork> result = artworkService.getAllArtworks();
 
         // Then
         assertThat(result).hasSize(2);
@@ -111,7 +111,7 @@ class ArtworkServiceTest {
 
     @Test
     @DisplayName("Artwork 업데이트 성공")
-    void testUpdateArtwork() throws MalformedURLException {
+    void testModifyArtwork() throws MalformedURLException {
         // Given
         Artwork existingArtwork = new Artwork(1L, "Old Title", new URL("http://example.com/old_image.jpg"));
         ArtworkUpdateRequest request = new ArtworkUpdateRequest("Updated Title", new URL("http://example.com/new_image.jpg"));
@@ -119,7 +119,7 @@ class ArtworkServiceTest {
         when(artworkRepository.findById(1L)).thenReturn(Optional.of(existingArtwork));
 
         // When
-        artworkService.updateArtwork(1L, request);
+        artworkService.modifyArtwork(1L, request);
 
         // Then
         assertThat(existingArtwork.getTitle()).isEqualTo("Updated Title");
@@ -135,20 +135,20 @@ class ArtworkServiceTest {
         when(artworkRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> artworkService.updateArtwork(1L, request))
+        assertThatThrownBy(() -> artworkService.modifyArtwork(1L, request))
                 .isInstanceOf(ArtworkNotFoundException.class)
                 .hasMessage("Artwork with ID 1 not found");
     }
 
     @Test
     @DisplayName("Artwork 삭제 성공")
-    void testDeleteArtwork() throws MalformedURLException {
+    void testRemoveArtwork() throws MalformedURLException {
         // Given
         Artwork artwork = new Artwork(1L, "Artwork", new URL("http://example.com/image.jpg"));
         when(artworkRepository.findById(1L)).thenReturn(Optional.of(artwork));
 
         // When
-        artworkService.deleteArtwork(1L);
+        artworkService.removeArtwork(1L);
 
         // Then
         verify(artworkRepository, times(1)).delete(artwork);
@@ -161,7 +161,7 @@ class ArtworkServiceTest {
         when(artworkRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> artworkService.deleteArtwork(1L))
+        assertThatThrownBy(() -> artworkService.removeArtwork(1L))
                 .isInstanceOf(ArtworkNotFoundException.class)
                 .hasMessage("Artwork with ID 1 not found");
     }

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/character/service/CharacterServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/character/service/CharacterServiceTest.java
@@ -69,7 +69,7 @@ class CharacterServiceTest {
                 .basePrompt(request.basePrompt())
                 .build();
 
-        when(characterArtworkService.readById(request.artworkId())).thenReturn(artwork);
+        when(characterArtworkService.getById(request.artworkId())).thenReturn(artwork);
         when(characterRepository.save(any(Character.class))).thenReturn(character);
 
         // when
@@ -223,7 +223,7 @@ class CharacterServiceTest {
         CharacterUpdateRequest request = new CharacterUpdateRequest(updateCharacterVisionType, PaymentType.PAID, updateArtworkId, updateCharacterName, updateUrl, updatedBasePrompt);
 
         when(characterRepository.findById(characterId)).thenReturn(Optional.of(character));
-        when(characterArtworkService.readById(request.artworkId())).thenReturn(updateArtwork);
+        when(characterArtworkService.getById(request.artworkId())).thenReturn(updateArtwork);
 
         // when
         characterService.modifyCharacter(characterId, request);

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/character/service/CharacterServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/character/service/CharacterServiceTest.java
@@ -1,6 +1,5 @@
 package com.startingblue.fourtooncookie.character.service;
 
-import com.startingblue.fourtooncookie.artwork.ArtworkService;
 import com.startingblue.fourtooncookie.artwork.domain.Artwork;
 import com.startingblue.fourtooncookie.character.CharacterService;
 import com.startingblue.fourtooncookie.character.domain.Character;
@@ -74,7 +73,7 @@ class CharacterServiceTest {
         when(characterRepository.save(any(Character.class))).thenReturn(character);
 
         // when
-        characterService.createCharacter(request);
+        characterService.addCharacter(request);
 
         // then
         assertThat(character.getCharacterVisionType()).isEqualTo(characterVisionType);
@@ -103,7 +102,7 @@ class CharacterServiceTest {
         when(characterRepository.findById(characterId)).thenReturn(Optional.of(character));
 
         // when
-        Character foundCharacter = characterService.readById(characterId);
+        Character foundCharacter = characterService.getById(characterId);
 
         // then
         assertThat(foundCharacter).isNotNull();
@@ -124,7 +123,7 @@ class CharacterServiceTest {
         when(characterRepository.findById(notFoundCharacterId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(CharacterNotFoundException.class, () -> characterService.readById(notFoundCharacterId));
+        assertThrows(CharacterNotFoundException.class, () -> characterService.getById(notFoundCharacterId));
         verify(characterRepository, times(1)).findById(notFoundCharacterId);
     }
 
@@ -163,7 +162,7 @@ class CharacterServiceTest {
         when(characterRepository.findAll()).thenReturn(List.of(character1, character2));
 
         // when
-        CharacterSavedResponses characterSavedResponses = CharacterSavedResponses.of(characterService.readAllCharacters(Locale.KOREAN));
+        CharacterSavedResponses characterSavedResponses = CharacterSavedResponses.of(characterService.getAllCharacters(Locale.KOREAN));
 
         // then
         assertThat(characterSavedResponses.characterSavedResponses()).hasSize(2);
@@ -202,7 +201,7 @@ class CharacterServiceTest {
 
     @DisplayName("캐릭터를 수정한다.")
     @Test
-    void updateCharacterSuccessfully() throws MalformedURLException {
+    void modifyCharacterSuccessfully() throws MalformedURLException {
         // given
         Artwork artwork = new Artwork("Test Artwork", new URL("https://test.png"));
         Character character = Character.builder()
@@ -227,8 +226,8 @@ class CharacterServiceTest {
         when(characterArtworkService.readById(request.artworkId())).thenReturn(updateArtwork);
 
         // when
-        characterService.updateCharacter(characterId, request);
-        Character updatedCharacter = characterService.readById(characterId);
+        characterService.modifyCharacter(characterId, request);
+        Character updatedCharacter = characterService.getById(characterId);
 
         // then
         assertThat(updatedCharacter.getCharacterVisionType()).isEqualTo(updateCharacterVisionType);
@@ -255,13 +254,13 @@ class CharacterServiceTest {
         when(characterRepository.findById(notFoundCharacterId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(CharacterNotFoundException.class, () -> characterService.updateCharacter(notFoundCharacterId, request));
+        assertThrows(CharacterNotFoundException.class, () -> characterService.modifyCharacter(notFoundCharacterId, request));
         verify(characterRepository, times(1)).findById(notFoundCharacterId);
     }
 
     @DisplayName("캐릭터를 삭제한다.")
     @Test
-    void deleteCharacterSuccessfully() throws MalformedURLException {
+    void removeCharacterSuccessfully() throws MalformedURLException {
         // given
         Long characterId = 1L;
         String basePrompt = "This is a base prompt";
@@ -277,7 +276,7 @@ class CharacterServiceTest {
         when(characterRepository.findById(characterId)).thenReturn(Optional.of(character));
 
         // when
-        characterService.deleteCharacter(characterId);
+        characterService.removeCharacter(characterId);
         when(characterRepository.findById(characterId)).thenReturn(Optional.empty());
 
         // then
@@ -295,7 +294,7 @@ class CharacterServiceTest {
         when(characterRepository.findById(notFoundCharacterId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(CharacterNotFoundException.class, () -> characterService.deleteCharacter(notFoundCharacterId));
+        assertThrows(CharacterNotFoundException.class, () -> characterService.removeCharacter(notFoundCharacterId));
         verify(characterRepository, times(1)).findById(notFoundCharacterId);
     }
 }

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilterTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilterTest.java
@@ -62,7 +62,7 @@ class AuthenticationFilterTest {
         when(jwtExtractor.parseToken("validToken")).thenReturn(claims);
         when(claims.getSubject()).thenReturn(memberId.toString());
 
-        when(memberService.verifyMemberExists(memberId)).thenReturn(true);
+        when(memberService.isMemberSignUp(memberId)).thenReturn(true);
 
         // When
         authenticationFilter.doFilter(request, response, filterChain);
@@ -99,7 +99,7 @@ class AuthenticationFilterTest {
         when(jwtExtractor.parseToken("validToken")).thenReturn(claims);
         when(claims.getSubject()).thenReturn(memberId.toString());
 
-        when(memberService.verifyMemberExists(memberId)).thenReturn(false);
+        when(memberService.isMemberSignUp(memberId)).thenReturn(false);
 
         // When
         authenticationFilter.doFilter(request, response, filterChain);
@@ -142,7 +142,7 @@ class AuthenticationFilterTest {
         when(claims.getSubject()).thenReturn(memberId.toString());
 
         // Mock 회원 존재 여부
-        when(memberService.verifyMemberExists(memberId)).thenReturn(true);
+        when(memberService.isMemberSignUp(memberId)).thenReturn(true);
 
         // When
         authenticationFilter.doFilter(request, response, filterChain);

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/authorization/DiaryOwnerAuthorizationInterceptorTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/authorization/DiaryOwnerAuthorizationInterceptorTest.java
@@ -48,14 +48,14 @@ class DiaryOwnerAuthorizationInterceptorTest {
         request.setRequestURI("/diary/" + validDiaryId);
         request.setAttribute("memberId", validMemberId);
 
-        when(diaryService.verifyDiaryOwner(UUID.fromString(validMemberId), validDiaryId)).thenReturn(true);
+        when(diaryService.isDiaryOwner(UUID.fromString(validMemberId), validDiaryId)).thenReturn(true);
 
         // When
         boolean result = diaryOwnerAuthorizationInterceptor.preHandle(request, response, new Object());
 
         // Then
         assertTrue(result);
-        verify(diaryService, times(1)).verifyDiaryOwner(UUID.fromString(validMemberId), validDiaryId);
+        verify(diaryService, times(1)).isDiaryOwner(UUID.fromString(validMemberId), validDiaryId);
     }
 
     @Test
@@ -71,7 +71,7 @@ class DiaryOwnerAuthorizationInterceptorTest {
         // Then
         assertFalse(result);
         assertTrue(response.getStatus() == HttpServletResponse.SC_FORBIDDEN);
-        verify(diaryService, never()).verifyDiaryOwner(any(UUID.class), anyLong());
+        verify(diaryService, never()).isDiaryOwner(any(UUID.class), anyLong());
     }
 
     @Test
@@ -88,7 +88,7 @@ class DiaryOwnerAuthorizationInterceptorTest {
         // Then
         assertFalse(result);
         assertTrue(response.getStatus() == HttpServletResponse.SC_FORBIDDEN);
-        verify(diaryService, never()).verifyDiaryOwner(any(UUID.class), anyLong());
+        verify(diaryService, never()).isDiaryOwner(any(UUID.class), anyLong());
     }
 
     @Test
@@ -101,7 +101,7 @@ class DiaryOwnerAuthorizationInterceptorTest {
         request.setRequestURI("/diary/" + validDiaryId);
         request.setAttribute("memberId", validMemberId);
 
-        when(diaryService.verifyDiaryOwner(UUID.fromString(validMemberId), validDiaryId)).thenReturn(false);
+        when(diaryService.isDiaryOwner(UUID.fromString(validMemberId), validDiaryId)).thenReturn(false);
 
         // When
         boolean result = diaryOwnerAuthorizationInterceptor.preHandle(request, response, new Object());
@@ -109,7 +109,7 @@ class DiaryOwnerAuthorizationInterceptorTest {
         // Then
         assertFalse(result);
         assertTrue(response.getStatus() == HttpServletResponse.SC_FORBIDDEN);
-        verify(diaryService, times(1)).verifyDiaryOwner(UUID.fromString(validMemberId), validDiaryId);
+        verify(diaryService, times(1)).isDiaryOwner(UUID.fromString(validMemberId), validDiaryId);
     }
 
     @ParameterizedTest
@@ -131,6 +131,6 @@ class DiaryOwnerAuthorizationInterceptorTest {
         // Then
         assertFalse(result);
         assertTrue(response.getStatus() == HttpServletResponse.SC_FORBIDDEN); // 403 Forbidden 응답
-        verify(diaryService, never()).verifyDiaryOwner(any(UUID.class), anyLong()); // diaryService는 호출되지 않아야 함
+        verify(diaryService, never()).isDiaryOwner(any(UUID.class), anyLong()); // diaryService는 호출되지 않아야 함
     }
 }

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
@@ -94,7 +94,7 @@ class DiaryServiceTest {
         // given
         Diary diary = addDiary(LocalDate.of(2024, 7, 21), character, member);
         diaryRepository.save(diary);
-        doNothing().when(diaryS3Service).deleteImagesByDiaryId(anyLong());
+        doNothing().when(diaryS3Service).removeImagesByDiaryId(anyLong());
 
         // when
         diaryService.removeDiaryById(diary.getId());

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/global/authorization/member/MemberAdminAuthorizationInterceptorTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/global/authorization/member/MemberAdminAuthorizationInterceptorTest.java
@@ -93,7 +93,7 @@ class MemberAdminAuthorizationInterceptorTest {
     @Test
     void whenAdminMemberIdThenTrue() {
         //given & then
-        when(memberService.verifyMemberAdmin(any())).thenReturn(true);
+        when(memberService.isMemberAdmin(any())).thenReturn(true);
         UUID randomUUID = UUID.randomUUID();
         boolean result = memberAdminAuthorizationInterceptor.isAuthorized(randomUUID);
 
@@ -105,7 +105,7 @@ class MemberAdminAuthorizationInterceptorTest {
     @Test
     void whenNotAdminMemberIdThenFalse() {
         //given & then
-        when(memberService.verifyMemberAdmin(any())).thenReturn(false);
+        when(memberService.isMemberAdmin(any())).thenReturn(false);
         UUID randomUUID = UUID.randomUUID();
         boolean result = memberAdminAuthorizationInterceptor.isAuthorized(randomUUID);
 

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/global/authorization/member/MemberSignedUpAuthorizationInterceptorTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/global/authorization/member/MemberSignedUpAuthorizationInterceptorTest.java
@@ -62,7 +62,7 @@ class MemberSignedUpAuthorizationInterceptorTest {
     void whenAdminMemberIdThenTrue() {
         //given & then
         UUID uuid = UUID.randomUUID();
-        when(memberService.verifyMemberSignUp(uuid)).thenReturn(true);
+        when(memberService.isMemberSignUp(uuid)).thenReturn(true);
         boolean result = memberSignedUpAuthorizationInterceptor.isAuthorized(uuid);
 
         //then
@@ -74,7 +74,7 @@ class MemberSignedUpAuthorizationInterceptorTest {
     void whenNotAdminMemberIdThenFalse() {
         //given & then
         UUID uuid = UUID.randomUUID();
-        when(memberService.verifyMemberSignUp(uuid)).thenReturn(false);
+        when(memberService.isMemberSignUp(uuid)).thenReturn(false);
         boolean result = memberSignedUpAuthorizationInterceptor.isAuthorized(uuid);
 
         //then

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
@@ -115,7 +115,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("멤버를 성공적으로 삭제")
     void removeById_DeletesMember_WhenCalled() {
-        doNothing().when(memberDiaryService).deleteDiariesByMemberId(memberId);
+        doNothing().when(memberDiaryService).removeDiariesByMemberId(memberId);
 
         // when
         memberService.removeById(memberId);

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
@@ -60,12 +60,12 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버 저장 시 중복 멤버가 있는 경우 MemberDuplicateException 발생")
-    void save_ThrowsException_WhenMemberExists() {
+    void add_Member_ThrowsException_WhenMemberExists() {
         // given
         when(memberRepository.existsById(memberId)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> memberService.save(memberId, memberSaveRequest))
+        assertThatThrownBy(() -> memberService.addMember(memberId, memberSaveRequest))
                 .isInstanceOf(MemberDuplicateException.class)
                 .hasMessageContaining("Member with id " + memberId + " already exists");
 
@@ -74,12 +74,12 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("새로운 멤버를 성공적으로 저장")
-    void save_Success_WhenMemberDoesNotExist() {
+    void add_Member_Success_WhenMemberDoesNotExist() {
         // given
         when(memberRepository.existsById(memberId)).thenReturn(false);
 
         // when
-        memberService.save(memberId, memberSaveRequest);
+        memberService.addMember(memberId, memberSaveRequest);
 
         // then
         verify(memberRepository, times(1)).save(any(Member.class)); // 한 번 호출
@@ -87,12 +87,12 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버 ID로 조회 시 멤버를 찾는다.")
-    void readById_ReturnsMember_WhenMemberExists() {
+    void getById_ReturnsMember_WhenMemberExists() {
         // given
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 
         // when
-        Member foundMember = memberService.readById(memberId);
+        Member foundMember = memberService.getById(memberId);
 
         // then
         assertThat(foundMember).isNotNull();
@@ -102,62 +102,36 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버 ID로 조회 시 멤버를 찾을 수 없을 때 MemberNotFoundException 발생")
-    void readById_ThrowsException_WhenMemberNotFound() {
+    void getById_ThrowsException_WhenMemberNotFound() {
         // given
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> memberService.readById(memberId))
+        assertThatThrownBy(() -> memberService.getById(memberId))
                 .isInstanceOf(MemberNotFoundException.class)
                 .hasMessageContaining("member not found");
     }
 
     @Test
     @DisplayName("멤버를 성공적으로 삭제")
-    void hardDeleteById_DeletesMember_WhenCalled() {
+    void removeById_DeletesMember_WhenCalled() {
         doNothing().when(memberDiaryService).deleteDiariesByMemberId(memberId);
 
         // when
-        memberService.hardDeleteById(memberId);
+        memberService.removeById(memberId);
 
         // then
         verify(memberRepository, times(1)).deleteById(memberId); // 삭제 호출
     }
 
     @Test
-    @DisplayName("멤버 존재 여부를 확인")
-    void verifyMemberExists_ReturnsTrue_WhenMemberExists() {
-        // given
-        when(memberRepository.existsById(memberId)).thenReturn(true);
-
-        // when
-        boolean exists = memberService.verifyMemberExists(memberId);
-
-        // then
-        assertThat(exists).isTrue();
-    }
-
-    @Test
-    @DisplayName("멤버가 존재하지 않으면 false 반환")
-    void verifyMemberExists_ReturnsFalse_WhenMemberNotExists() {
-        // given
-        when(memberRepository.existsById(memberId)).thenReturn(false);
-
-        // when
-        boolean exists = memberService.verifyMemberExists(memberId);
-
-        // then
-        assertThat(exists).isFalse();
-    }
-
-    @Test
     @DisplayName("멤버의 가입 여부 확인")
-    void verifyMemberSignUp_ReturnsTrue_WhenSignedUp() {
+    void isMemberSignUp_ReturnsTrue_WhenSignedUp() {
         // given
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 
         // when
-        boolean signedUp = memberService.verifyMemberSignUp(memberId);
+        boolean signedUp = memberService.isMemberSignUp(memberId);
 
         // then
         assertThat(signedUp).isTrue();
@@ -165,13 +139,13 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버의 가입 상태가 불완전할 경우 false 반환")
-    void verifyMemberSignUp_ReturnsFalse_WhenNotSignedUp() {
+    void isMemberSignUp_ReturnsFalse_WhenNotSignedUp() {
         // given
         Member incompleteMember = Member.builder().id(memberId).build();
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(incompleteMember));
 
         // when
-        boolean signedUp = memberService.verifyMemberSignUp(memberId);
+        boolean signedUp = memberService.isMemberSignUp(memberId);
 
         // then
         assertThat(signedUp).isFalse();
@@ -179,7 +153,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버가 관리자인 경우 true 반환")
-    void verifyMemberAdmin_ReturnsTrue_WhenAdmin() {
+    void isMemberAdmin_ReturnsTrue_WhenAdmin() {
         // given
         UUID adminMemberId = UUID.randomUUID();
         Member adminMember = Member.builder()
@@ -192,7 +166,7 @@ class MemberServiceTest {
         when(memberRepository.findById(adminMemberId)).thenReturn(Optional.of(adminMember));
 
         // when
-        boolean isAdmin = memberService.verifyMemberAdmin(adminMemberId);
+        boolean isAdmin = memberService.isMemberAdmin(adminMemberId);
 
         // then
         assertThat(isAdmin).isTrue();
@@ -200,12 +174,12 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("멤버가 관리자가 아닐 경우 false 반환")
-    void verifyMemberAdmin_ReturnsFalse_WhenNotAdmin() {
+    void isMemberAdmin_ReturnsFalse_WhenNotAdmin() {
         // given
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 
         // when
-        boolean isAdmin = memberService.verifyMemberAdmin(memberId);
+        boolean isAdmin = memberService.isMemberAdmin(memberId);
 
         // then
         assertThat(isAdmin).isFalse();


### PR DESCRIPTION
# [refactor] 메서드 이름 리팩토링
### Pull Request 타입
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-455
---
* 구현 내용
- Diary, Artwork, Member 관련 컨트롤러, 서비스 메서드 명 변경
- ArgumentResolve 메서드 명 변경
- DiaryOwnerAuthorizationInterceptor 메서드 명 변경

---
## 메서드 규칙
### 공통
- 메서드 순서는 CRUD 순서대로 위치

### 컨트롤러
- HTTP 메서드 명을 prefix로 둠. ex) postMember, getMember, patchMember, putMember, deleteMember

### 서비스
- JPARepository와 겹치지 않도록 구성
    - add (디비 = create)
    - get (디비 = read)
    - modify (디비 = update)
    - remove (디비 = delete)
    - validate~~~() - 예외를 던지는 메서드
    - is~~~~() - boolean을 반환하는 메서드
